### PR TITLE
implement icon for copy title to clipboard

### DIFF
--- a/src/app/evaluations/components/EvaluationCardComponent.tsx
+++ b/src/app/evaluations/components/EvaluationCardComponent.tsx
@@ -7,7 +7,18 @@ import {
 import Markdown from "markdown-to-jsx";
 import React, { useCallback, useState } from "react";
 import ImageViewer from "react-simple-image-viewer";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
 
+const copyToClipboard = async (text: string): Promise<void> => {
+    try {
+        await navigator.clipboard.writeText(text);
+        console.log("Title copied to clipboard");
+    } catch (err) {
+        console.error("Failed to copy: ", err);
+    }
+};
 export function EvaluationsCardComponent(props: {
     id: string; // Add this line to accept the id prop
     title: string;
@@ -48,9 +59,28 @@ export function EvaluationsCardComponent(props: {
                     <CardContent
                         sx={{
                             flex: "1 0 auto",
+                            display: "flex",
+                            justifyContent: "space-between", // Adjust if necessary
+                            alignItems: "center",
                         }}
                     >
                         <Markdown>{props.description}</Markdown>
+                        {/* IconButton with copy icon */}
+                        <Tooltip title="Copy to clipboard" arrow>
+                            <IconButton
+                                size="small"
+                                onClick={() => copyToClipboard(props.title)}
+                                aria-label="Copy title"
+                                sx={{
+                                    position: "absolute",
+                                    top: "5%",
+                                    left: "0px",
+                                    transform: "translateY(-50%)",
+                                }}
+                            >
+                                <ContentCopyIcon fontSize="inherit" />
+                            </IconButton>
+                        </Tooltip>
                     </CardContent>
                 </Box>
                 <Box

--- a/src/app/evaluations/model/constants.ts
+++ b/src/app/evaluations/model/constants.ts
@@ -46,8 +46,8 @@ const division = ["FUTTERMITTEL", "TIERE", "LEBENSMITTEL", "MULTIPLE"];
 const initialFilterSelection: FilterSelection = {
     division,
     microorganism,
-    productionType,
     category,
+    productionType,
     matrix,
     diagramType,
 };


### PR DESCRIPTION
If clicking on the titles triggers an action (like opening a box with details), then the text is likely not selectable because it's functioning as a button or link, not as static text. In such cases, the text is often part of an interactive element designed for user interaction rather than text selection.,,, for this i implement icon for copy title to clipboard
![image](https://github.com/SiLeBAT/zoonotify-client/assets/77792173/c36f1112-fb12-45f2-98d6-deb0fdf9177f)
