### PR TITLE
Id

### DIFF
--- a/src/app/antibiotic_resistance/pages/TrendDetails.tsx
+++ b/src/app/antibiotic_resistance/pages/TrendDetails.tsx
@@ -35,7 +35,7 @@ import {
     RESISTANCES,
 } from "../../shared/infrastructure/router/routes";
 import Markdown from "markdown-to-jsx";
-import type { MenuProps } from "@mui/material/Menu"; // add this import
+import type { MenuProps } from "@mui/material/Menu";
 import { SidebarComponent } from "../../shared/components/layout/SidebarComponent";
 
 import { TrendChart } from "./TrendChart";
@@ -425,9 +425,8 @@ export const TrendDetails: React.FC<{
     >([]);
     const [showChart, setShowChart] = useState(false);
 
-    // For substances multi-select at top
     const [substanceFilter, setSubstanceFilter] = useState<string[]>([]);
-    // To update available substance options
+
     const [allSubstances, setAllSubstances] = useState<FilterOption[]>([]);
 
     const [currentPage, setCurrentPage] = useState(1);
@@ -522,7 +521,7 @@ export const TrendDetails: React.FC<{
         }
         if (microorganism) {
             fetchResistanceOptions();
-            // Only hide chart when microorganism changes, not on language change
+
             if (!hydratedFromUrlRef.current) {
                 setShowChart(false);
             }
@@ -728,7 +727,7 @@ export const TrendDetails: React.FC<{
             samplingStage: computeOptions("samplingStage"),
             matrixGroup: computeOptions("matrixGroup"),
             matrix: computeOptions("matrix"),
-            antimicrobialSubstance: computeOptions("antimicrobialSubstance"), // keep if you want top multi-select to shrink too
+            antimicrobialSubstance: computeOptions("antimicrobialSubstance"),
         };
 
         setFilterOptions(next);
@@ -790,7 +789,6 @@ export const TrendDetails: React.FC<{
         //setCurrentPage(1);
     }, [substanceFilter]);
 
-    // RESET
     const resetFilters = (): void => {
         setSelected({ ...emptyFilterState });
         setShowChart(false);
@@ -865,8 +863,8 @@ export const TrendDetails: React.FC<{
                         value={substanceFilter}
                         onChange={handleChange}
                         label={t("ANTIBIOTIC_SUBSTANCE")}
-                        sx={selectSx} //  fixed trigger width + ellipsis
-                        MenuProps={fixedMenuProps} //  fixed menu width + anchor
+                        sx={selectSx}
+                        MenuProps={fixedMenuProps}
                         renderValue={(selectedItems) =>
                             Array.isArray(selectedItems)
                                 ? substances

--- a/src/app/antibiotic_resistance/pages/resistanceHelpers.ts
+++ b/src/app/antibiotic_resistance/pages/resistanceHelpers.ts
@@ -1,0 +1,134 @@
+// --- Shared types and helper functions for resistance pages ---
+
+export type FilterKey =
+    | "samplingYear"
+    | "antimicrobialSubstance"
+    | "specie"
+    | "superCategorySampleOrigin"
+    | "sampleOrigin"
+    | "samplingStage"
+    | "matrixGroup"
+    | "matrix";
+
+export type FilterOption = {
+    id: string;
+    name: string;
+    documentId: string;
+};
+
+export const emptyFilterState: Record<FilterKey, string[]> = {
+    samplingYear: [],
+    antimicrobialSubstance: [],
+    specie: [],
+    superCategorySampleOrigin: [],
+    sampleOrigin: [],
+    samplingStage: [],
+    matrixGroup: [],
+    matrix: [],
+};
+
+export interface ResistanceApiItem {
+    id: number;
+    samplingYear: number;
+    superCategorySampleOrigin?: {
+        id: number;
+        name: string;
+        documentId: string;
+    } | null;
+    sampleOrigin?: { id: number; name: string; documentId: string } | null;
+    samplingStage?: { id: number; name: string; documentId: string } | null;
+    matrixGroup?: { id: number; name: string; documentId: string } | null;
+    matrix?: { id: number; name: string; documentId: string } | null;
+    antimicrobialSubstance?: {
+        id: number;
+        name: string;
+        documentId: string;
+    } | null;
+    specie?: { id: number; name: string; documentId: string } | null;
+    resistenzrate: number;
+    anzahlGetesteterIsolate: number;
+    anzahlResistenterIsolate: number;
+    minKonfidenzintervall: number;
+    maxKonfidenzintervall: number;
+}
+
+const RELATION_FILTER_KEYS: FilterKey[] = [
+    "specie",
+    "superCategorySampleOrigin",
+    "sampleOrigin",
+    "samplingStage",
+    "matrixGroup",
+    "matrix",
+    "antimicrobialSubstance",
+];
+
+/** Get the relation object for a given filter key from a data item */
+export function getRelObject(
+    item: ResistanceApiItem,
+    key: FilterKey
+): { name: string; documentId: string } | null {
+    switch (key) {
+        case "specie":
+            return item.specie ?? null;
+        case "superCategorySampleOrigin":
+            return item.superCategorySampleOrigin ?? null;
+        case "sampleOrigin":
+            return item.sampleOrigin ?? null;
+        case "samplingStage":
+            return item.samplingStage ?? null;
+        case "matrixGroup":
+            return item.matrixGroup ?? null;
+        case "matrix":
+            return item.matrix ?? null;
+        case "antimicrobialSubstance":
+            return item.antimicrobialSubstance ?? null;
+        default:
+            return null;
+    }
+}
+
+/** Build docId->name map for all filter keys */
+export function buildDocIdToNameMap(
+    items: ResistanceApiItem[]
+): Record<FilterKey, Map<string, string>> {
+    const result = {} as Record<FilterKey, Map<string, string>>;
+    for (const k of RELATION_FILTER_KEYS) {
+        const m = new Map<string, string>();
+        for (const item of items) {
+            const obj = getRelObject(item, k);
+            if (obj?.documentId && obj?.name) m.set(obj.documentId, obj.name);
+        }
+        result[k] = m;
+    }
+    result.samplingYear = new Map<string, string>();
+    return result;
+}
+
+/** Build name->docId map for all filter keys */
+export function buildNameToDocIdMap(
+    items: ResistanceApiItem[]
+): Record<FilterKey, Map<string, string>> {
+    const result = {} as Record<FilterKey, Map<string, string>>;
+    for (const k of RELATION_FILTER_KEYS) {
+        const m = new Map<string, string>();
+        for (const item of items) {
+            const obj = getRelObject(item, k);
+            if (obj?.name && obj?.documentId) m.set(obj.name, obj.documentId);
+        }
+        result[k] = m;
+    }
+    result.samplingYear = new Map<string, string>();
+    return result;
+}
+
+/** Resolve a URL value (name or old docId) to docId with backwards compat */
+export function resolveUrlValueToDocId(
+    value: string,
+    nameToDocId: Map<string, string>,
+    docIdToName: Map<string, string>
+): string | undefined {
+    const byName = nameToDocId.get(value);
+    if (byName) return byName;
+    if (docIdToName.has(value)) return value;
+    return undefined;
+}

--- a/src/app/prevalence/components/PrevalenceDataContext.tsx
+++ b/src/app/prevalence/components/PrevalenceDataContext.tsx
@@ -1,4 +1,5 @@
 import i18next from "i18next";
+import { resolveUrlValueToDocId as resolveUrlValueToDocIdBase } from "../../antibiotic_resistance/pages/resistanceHelpers";
 import React, {
     ReactNode,
     createContext,
@@ -115,18 +116,14 @@ const writeChartMicroToUrl = (microName: string): void => {
     }
 };
 
-/** URL <-> docId resolution helpers */
+/** URL <-> docId resolution helpers (uses shared helper from resistanceHelpers) */
 function resolveUrlValueToDocId(
     value: string,
     options: Option[]
 ): string | undefined {
-    // Name-match first (new format)
-    const byName = options.find((o) => o.name === value);
-    if (byName) return byName.documentId;
-    // Backwards compat: try matching as old-format documentId
-    const byDocId = options.find((o) => o.documentId === value);
-    if (byDocId) return byDocId.documentId;
-    return undefined;
+    const nameToDocId = new Map(options.map((o) => [o.name, o.documentId]));
+    const docIdToName = new Map(options.map((o) => [o.documentId, o.name]));
+    return resolveUrlValueToDocIdBase(value, nameToDocId, docIdToName);
 }
 
 function resolveDocIdToName(docId: string, options: Option[]): string {


### PR DESCRIPTION
###  **Fix**

  I use entity names in URLs instead of documentId. Names are stable across re-imports. Internal state and API queries continue to use documentId — only the URL serialization layer changes.

  ### **Changes**

  **1. PrevalenceDataContext.tsx**
  - Added two helper functions: resolveUrlValueToDocId (URL name → docId when reading) and resolveDocIdToName (docId →   
  name when writing)
  - Added an optionsRef to hold current filter options synchronously for URL resolution
  - Writing URL: Before appending filter values to the URL, each docId is converted to its name via resolveDocIdToName   
  - Reading URL: On page load, URL values are resolved back to docIds via resolveUrlValueToDocId
  - Language change: fetchOptions() is always called first so the ref has current-locale names before the URL is
  rewritten

  **2. SubstanceDetail.tsx**
  - Added buildDocIdToNameMap / buildNameToDocIdMap helpers that build lookup maps from the resistance data
  - encodeStateToParam: Before compressing the payload, filter docIds are converted to names
  - readStateFromUrlCompressed: After decompressing, names are resolved back to docIds
  - getComboIdKey: Changed from documentId to name for stable combination keys
  - All 7 call sites updated to pass resistanceRawData for the conversion

  **3. TrendDetails.tsx** 
  - Added the same buildDocIdToNameMap / buildNameToDocIdMap / resolveUrlValueToDocIdTrend helpers
  - updateTrendFilterUrl: Converts docIds to names when writing URL params
  - readTrendFilterStateFromUrl: Resolves names back to docIds when reading URL params
  - Added hydratedFromUrlRef so the URL is only read once on initial load. On language change, the existing filter state 
  (docIds) is preserved and only the URL is rewritten with new-locale names
  - After language refetch, filteredFullData is recomputed so cascading dropdown options update immediately