### PR TITLE
Fix UTF-8 encoding for German umlauts in CSV downloads

### DIFF
--- a/src/app/antibiotic_resistance/pages/SubstanceChart.tsx
+++ b/src/app/antibiotic_resistance/pages/SubstanceChart.tsx
@@ -358,8 +358,9 @@ export const SubstanceChart: React.FC<SubstanceChartProps> = ({
         const timestamp = getFormattedTimestamp();
         const zip = new JSZip();
 
-        const csvComma = generateCSV(rows, ",", ".");
-        const csvDot = generateCSV(rows, ";", ",");
+        const BOM = "\uFEFF";
+        const csvComma = BOM + generateCSV(rows, ",", ".");
+        const csvDot = BOM + generateCSV(rows, ";", ",");
 
         const readmeContentEn = `
 This ZooNotify data download contains this README-file and two CSV-files. The use of these CSV-files is explained below.

--- a/src/app/antibiotic_resistance/pages/TrendChart.tsx
+++ b/src/app/antibiotic_resistance/pages/TrendChart.tsx
@@ -347,8 +347,9 @@ export const TrendChart: React.FC<TrendChartProps> = ({
         const timestamp = getFormattedTimestamp();
         const zip = new JSZip();
 
-        const csvComma = generateCSV(rows, ",", ".", t);
-        const csvDot = generateCSV(rows, ";", ",", t);
+        const BOM = "\uFEFF";
+        const csvComma = BOM + generateCSV(rows, ",", ".", t);
+        const csvDot = BOM + generateCSV(rows, ";", ",", t);
 
         const readmeContentDe = `
 Dieser ZooNotify-Daten-Download enthält diese README-Datei und zwei CSV-Dateien. Die Verwendung der CSV-Dateien wird im Folgenden erläutert.


### PR DESCRIPTION
  Add UTF-8 BOM to exported CSV files in SubstanceChart and TrendChart                           so that Excel correctly displays special characters (Ä, ä, Ü, ü, Ö, ö, ß)                      instead of garbled text when the app language is set to German.