### PR TITLE
Fix: Added the exact same <style> override to SubstanceDetail.tsx so the breadcrumb renders as a normal

### DIFF
--- a/src/app/antibiotic_resistance/pages/SubstanceDetail.tsx
+++ b/src/app/antibiotic_resistance/pages/SubstanceDetail.tsx
@@ -1375,6 +1375,7 @@ export const SubstanceDetail: React.FC<{
     return (
         <>
             <style>{menuItemTextStyle}</style>
+            <style>{`.abx-breadcrumb { position: static !important; z-index: 1 !important; }`}</style>
 
             <Box
                 display="flex"


### PR DESCRIPTION
…

  static element inside the scrollable main content area — matching how it works in Trend.