### PR TITLE
fix(znrc1743): rebuild page layout as a flex app-shell

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,15 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run format
-npm run lint:fix
-git add .
+# Only format/lint the files that are actually staged for this commit.
+# Running prettier/eslint over the whole src/ tree (plus `git add .`) swept
+# every file into the commit — on a CRLF checkout prettier rewrote each
+# file's line endings, producing a 100+ file diff on every commit.
+files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.js' '*.jsx' '*.ts' '*.tsx')
+if [ -n "$files" ]; then
+  echo "$files" | xargs npx prettier --write
+  echo "$files" | xargs npx eslint --fix
+  echo "$files" | xargs git add
+fi
+
 npm test -- --watchAll=false

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+    "endOfLine": "auto"
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,11 @@ module.exports = {
       "^.+\\.(js|jsx|ts|tsx)$": "babel-jest",
     },
     testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    // Ignore the .claude/ directory (e.g. git worktrees created under
+    // .claude/worktrees/), otherwise jest discovers a second copy of every
+    // test there and the duplicate package.json trips the haste-map.
+    testPathIgnorePatterns: ["/node_modules/", "/\\.claude/"],
+    modulePathIgnorePatterns: ["/\\.claude/"],
     moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
     moduleNameMapper: {
       "\\.(jpg|jpeg|png|gif|svg)$": "<rootDir>/empty-module.js",

--- a/src/app/prevalence/components/PrevalenceSideContent.tsx
+++ b/src/app/prevalence/components/PrevalenceSideContent.tsx
@@ -703,12 +703,11 @@ export function PrevalenceSideContent(): JSX.Element {
                 maxWidth: "95%",
                 p: 2,
                 boxSizing: "border-box",
-                height: "100vh",
-                maxHeight: "100vh",
-                "@supports (height: 100dvh)": {
-                    height: "100dvh",
-                    maxHeight: "100dvh",
-                },
+                // Fill the layout container (MainWithSideLayout) rather than the
+                // full viewport, so the inner scroll area sizes correctly and the
+                // Search/Reset buttons stay visible at the bottom.
+                height: "100%",
+                maxHeight: "100%",
             }}
         >
             <Box

--- a/src/app/shared/components/footer/Footer-Layout.component.tsx
+++ b/src/app/shared/components/footer/Footer-Layout.component.tsx
@@ -17,8 +17,11 @@ export function FooterLayoutComponent({
         <Box
             component="footer"
             sx={{
-                // On mobile (xs, sm), let it scroll with the page:
+                // Bottom row of the app-shell column (sibling of header/body).
+                // flexShrink: 0 keeps it at its natural height so it is always
+                // visible and never gets squeezed or scrolled off-screen.
                 position: "static",
+                flexShrink: 0,
                 width: "100%",
                 backgroundColor: theme.palette.background.paper,
                 borderTop: `2px solid ${theme.palette.primary.main}`,
@@ -28,18 +31,16 @@ export function FooterLayoutComponent({
                 padding: theme.spacing(1),
                 boxSizing: "border-box",
 
-                // On md+ (≥900px by default), fix it at the bottom:
+                // On md+ (≥900px by default), render it as a single row. It sits
+                // at the bottom of the app-shell column as a natural-height flex
+                // item, so it no longer needs position: fixed.
                 [theme.breakpoints.up("md")]: {
-                    position: "fixed",
-                    bottom: 0,
-                    left: 0,
-                    right: 0,
                     height: `${footerHeight}px`,
                     flexDirection: "row",
                     alignItems: "center",
                     justifyContent: "space-between",
                     padding: theme.spacing(0, 2),
-                    zIndex: 1000, // Added z-index to ensure footer stays above other content
+                    zIndex: 1000,
                 },
             }}
         >

--- a/src/app/shared/components/header/Header.component.tsx
+++ b/src/app/shared/components/header/Header.component.tsx
@@ -20,9 +20,10 @@ const headerStyle = css`
     display: flex;
     flex-direction: column;
     box-sizing: border-box;
-    position: fixed;
-    top: 0;
-    left: 0;
+    /* App-shell header: a natural-height flex item at the top of the column,
+       not position: fixed, so the body below never needs to reserve a
+       hardcoded header height. */
+    flex: 0 0 auto;
     z-index: 1000;
 `;
 

--- a/src/app/shared/components/layout/MainContentComponent.tsx
+++ b/src/app/shared/components/layout/MainContentComponent.tsx
@@ -19,9 +19,16 @@ export const MainContentComponent: React.FC<MainContentComponentProps> = ({
     return (
         <Item
             sx={{
-                overflow: "auto",
+                // The page content (PrevalenceMainContent / EvaluationMainContent)
+                // owns its own scroll container, so clip here instead of adding a
+                // second nested scrollbar on the results side.
+                overflow: "hidden",
                 width: "100%",
                 height: "100%",
+                // The app only sets border-box on <html>, not universally, so this
+                // Paper is content-box by default and its padding would add 16px on
+                // top of height:100%, overflowing main. Keep it inside its box.
+                boxSizing: "border-box",
                 marginLeft: "20px",
                 boxShadow: "15px 0 15px -15px inset",
             }}

--- a/src/app/shared/components/layout/MainWithSideLayoutComponent.tsx
+++ b/src/app/shared/components/layout/MainWithSideLayoutComponent.tsx
@@ -24,9 +24,17 @@ export const MainWithSideLayout: React.FC<LayoutProps> = ({
         <Box
             style={{
                 display: "flex",
-                width: "100vw",
-                height: "100vh",
-                maxHeight: "calc(100vh )",
+                // Fill the main scroll area handed to us by PageLayoutComponent.
+                // Use 100% (not 100vw/100vh) so the box tracks its container and
+                // never overflows by the scrollbar width or the header height.
+                width: "100%",
+                height: "100%",
+                maxHeight: "100%",
+                // Clip and allow the row to shrink so a tall sidebar/content pane
+                // scrolls inside its own panel instead of stretching this row and
+                // forcing main to scroll.
+                minHeight: 0,
+                overflow: "hidden",
             }}
         >
             <SidebarComponent

--- a/src/app/shared/components/layout/PageLayoutComponent.tsx
+++ b/src/app/shared/components/layout/PageLayoutComponent.tsx
@@ -1,31 +1,31 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
 import React, { useState } from "react";
-import { FooterContainer } from "../footer/Footer-Container.component";
 import { ErrorSnackbar } from "../ErrorSnackbar/ErrorSnackbar";
 
-// Wrapper: no fixed height or forced 100vh
+// The page fills the body slot handed down by MainLayout (between the global
+// header and footer) and owns its scrolling via main. The footer now lives in
+// MainLayout as a sibling of the header, so it is not part of this component.
 const layoutWrapperStyle = css`
-    //display: flex;
+    display: flex;
     flex-direction: column;
+    height: 100%;
     box-sizing: border-box;
 
-    overflow-y: hidden;
+    overflow: hidden;
 `;
 
-// Main content can scroll freely
+// Main is the page's scroll container. min-height: 0 lets it shrink inside the
+// flex column so it scrolls instead of overflowing. Pages that bring their own
+// scrollable panes (e.g. prevalence's sidebar + results) simply fill it.
 const mainStyle = css`
-    flex: 1;
+    flex: 1 1 0;
+    min-height: 0;
     z-index: 0;
     box-sizing: border-box;
 
-    /* Let the browser handle scrolling */
     overflow-x: hidden;
-    overflow-y: hidden;
-`;
-
-const footerStyle = css`
-    z-index: 1;
+    overflow-y: auto;
 `;
 
 interface PageLayoutProps {
@@ -44,10 +44,6 @@ export const PageLayoutComponent: React.FC<PageLayoutProps> = ({
     return (
         <div css={layoutWrapperStyle}>
             <main css={mainStyle}>{children}</main>
-
-            <footer css={footerStyle}>
-                <FooterContainer />
-            </footer>
 
             <ErrorSnackbar
                 open={snackbarOpen}

--- a/src/app/shared/layout/Main-Layout.component.tsx
+++ b/src/app/shared/layout/Main-Layout.component.tsx
@@ -4,23 +4,28 @@ import { BrowserRouter } from "react-router-dom";
 
 import { BodyRouterComponent } from "../infrastructure/router/Body-Router.component";
 import { HeaderComponent } from "../components/header/Header.component";
+import { FooterContainer } from "../components/footer/Footer-Container.component";
 
+// App shell: a full-viewport flex column. The header and footer take their
+// natural heights and the body flexes to fill whatever is left, so nothing
+// here depends on a hardcoded header/footer height.
 const wrapperStyle = css`
     height: 100%;
     display: flex;
     z-index: 100;
     flex-direction: column;
     box-sizing: border-box;
+    overflow: hidden;
 `;
 
+// Body holds the routed page between header and footer. It clips here; the
+// page's own main area (PageLayoutComponent) owns the scrolling.
 const bodyStyle = css`
     flex: 1 1 0;
-    margin-top: 42px;
-    margin-bottom: 42px;
+    min-height: 0;
     z-index: 0;
     box-sizing: border-box;
-    overflow-x: hidden;
-    overflow-y: auto;
+    overflow: hidden;
 `;
 
 /**
@@ -35,6 +40,7 @@ export function MainLayoutComponent(): JSX.Element {
                 <div css={bodyStyle}>
                     <BodyRouterComponent />
                 </div>
+                <FooterContainer />
             </BrowserRouter>
         </div>
     );

--- a/src/app/welcome/pages/WelcomeMainComponent.tsx
+++ b/src/app/welcome/pages/WelcomeMainComponent.tsx
@@ -18,19 +18,18 @@ export function WelcomeMainComponent(): JSX.Element {
 
     return (
         <PageLayoutComponent>
-            {/* Root container */}
+            {/* Root container: fill the main scroll area handed down by the
+                app-shell (PageLayoutComponent), not the whole viewport. Using
+                100vh here made this box taller than main and left empty space
+                above the footer plus an outer scrollbar. */}
             <Box
                 sx={{
-                    height: "100vh",
-                    width: "100vw",
-                    overflowY: "hidden", // Prevent outer scrollbar
+                    height: "100%",
+                    width: "100%",
+                    overflowY: "hidden",
                     display: "flex",
                     flexDirection: "column",
                     boxSizing: "border-box",
-                    // Mobile: use taller container
-                    "@media (max-width: 600px)": {
-                        height: "330vh",
-                    },
                 }}
             >
                 {/* Scrollable content area */}

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -23,10 +23,16 @@ body {
     width: 100%;
     margin: 0;
     padding: 0;
+    /* The app is a fixed-height shell (#application) that manages its own
+       internal scrolling. Clip the document so nothing — including elements
+       injected as <body> siblings by browser extensions — can make the whole
+       page scroll and push the fixed header/footer off-screen. */
+    overflow: hidden;
 }
 #application {
     width: 100%;
     height: 100%;
+    overflow: hidden;
 }
 
 span.react-simple-image-viewer__close {
@@ -36,4 +42,11 @@ span.react-simple-image-viewer__close {
 button em {
     padding-left: 0.2em;
     padding-right: 0.2em;
+}
+
+/* Some browser extensions inject a tooltip container as a sibling of the app
+   root. When it is in its hidden state it still occupies layout space, which
+   could push content/footer around. Remove it from layout entirely. */
+.__xwc-tooltip-hidden {
+    display: none !important;
 }


### PR DESCRIPTION
Replace the old fixed-position header/footer + hardcoded viewport-height calculations with a proper app-shell so the header and footer are always visible, only the main content scrolls, and nothing depends on an assumed header/footer height.

Layout:
- MainLayout is a flex column with header, body and footer as siblings; the footer was hoisted out of PageLayoutComponent. Header/footer are natural-height, non-shrinking flex items; the body flexes to fill the middle and PageLayoutComponent's main is the scroll container.
- MainWithSideLayout fills its container (100%, not 100vw/100vh) and clips so a tall sidebar/results pane scrolls within its own panel instead of forcing main to scroll. Results Paper is border-box so padding does not overflow main.
- Welcome page fills main (100%) instead of forcing 100vh.
- Prevalence: removed the redundant nested scrollbar so the filter panel and results panel each have a single scrollbar.
- html/body/#application get overflow: hidden so elements injected as body siblings (e.g. browser-extension tooltips) cannot scroll the whole document; the extension's hidden tooltip (.__xwc-tooltip-hidden) is also display:none.

Tooling:
- Scope the husky pre-commit hook to staged files instead of reformatting all of src/, and add a .prettierrc (endOfLine: auto) to stop CRLF line-ending churn on Windows.
- Make jest ignore the .claude/ worktree directory so duplicated test copies there don't fail the suite.