### PR TITLE
ZN-1758 Pin Node 20 in prod deploy (tags may predate .nvmrc)

### DIFF
--- a/.github/workflows/deploy-on-prod.yml
+++ b/.github/workflows/deploy-on-prod.yml
@@ -19,7 +19,9 @@ jobs:
           ref: ${{ inputs.tag }}
       - uses: actions/setup-node@v6
         with:
-          node-version-file: '.nvmrc'
+          # Pinned (not node-version-file) because this job checks out an
+          # arbitrary release tag, and older tags predate .nvmrc.
+          node-version: '20'
           cache: 'npm'
       - run: npm ci
 


### PR DESCRIPTION
## Problem

**Deploy to PROD** failed at the build step:

> The specified node version file at: .../.nvmrc does not exist

The prod deploy checks out the **release tag** being deployed (`ref: inputs.tag`). Tags created before `.nvmrc` was added (e.g. `v4.3.1`) don't contain it, so `setup-node`'s `node-version-file: '.nvmrc'` errors.

## Fix

Pin `node-version: '20'` directly in the prod build job. The other workflows (`ci`, `cd-qa`, `deploy-on-qa`, `cut-release`) keep `node-version-file: '.nvmrc'` since they always build current code (develop / rc-* / PR) that contains `.nvmrc`.

Single-line change to `deploy-on-prod.yml`. After merge, re-run **Deploy to PROD** with the tag.