### PR TITLE
ZN-1758 Merge release bump v4.3.2 back into develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zoonotify-client",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zoonotify-client",
-      "version": "4.3.1",
+      "version": "4.3.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zoonotify-client",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "Web-basierte Abfrage von Zoonosen Surveillancedaten",
   "scripts": {
     "prepare": "husky install",


### PR DESCRIPTION
Brings the `chore(release): 4.3.2` version bump (package.json/package-lock 4.3.1 → 4.3.2) from the rc-4.3.2 release branch back into develop, per the release flow (ADR 0001). The v4.3.2 tag + GitHub Release were already cut from this branch.