### PR TITLE
ZN-1758: Pin Node 20 in prod deploy + fix Dependabot auto-merge gate

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Dependabot metadata

--- a/.github/workflows/deploy-on-prod.yml
+++ b/.github/workflows/deploy-on-prod.yml
@@ -19,7 +19,9 @@ jobs:
           ref: ${{ inputs.tag }}
       - uses: actions/setup-node@v6
         with:
-          node-version-file: '.nvmrc'
+          # Pinned (not node-version-file) because this job checks out an
+          # arbitrary release tag, and older tags predate .nvmrc.
+          node-version: '20'
           cache: 'npm'
       - run: npm ci
 


### PR DESCRIPTION
## Summary
Branch `zn-1758-prod-node-version` into `develop`. Two commits:

- **Pin Node 20 in prod deploy** (tags may predate `.nvmrc`).
- **fix(ci): gate dependabot auto-merge on PR author not run actor** — `github.actor` reflects who triggered the run (a re-run or a `synchronize` push), so the auto-merge job skipped on genuine Dependabot PRs after the initial open. Now keys off `github.event.pull_request.user.login`, which stays `dependabot[bot]` across all events on the PR.

## Notes
Pushing to `develop` triggers the QA deploy per CI/CD.