### PR TITLE
feat(prevalence): add view-only year-range slider to charts

### DIFF
--- a/src/app/prevalence/components/PrevalenceChart.tsx
+++ b/src/app/prevalence/components/PrevalenceChart.tsx
@@ -3,6 +3,7 @@ import {
     CircularProgress,
     Grid,
     Pagination,
+    Slider,
     Typography,
     useMediaQuery,
 } from "@mui/material";
@@ -18,15 +19,11 @@ import { getCurrentTimestamp } from "./utils";
 
 ChartJS.register(...registerables);
 
-let [yearMin, yearMax] = [3000, 0];
-
 const PrevalenceChart: React.FC = () => {
     const {
         prevalenceData,
         loading,
         prevalenceUpdateDate,
-        selectedYear,
-        yearOptions,
         selectedChartMicroorganism,
         setSelectedChartMicroorganism,
     } = usePrevalenceFilters();
@@ -43,6 +40,42 @@ const PrevalenceChart: React.FC = () => {
         string[]
     >([]);
     const [currentPage, setCurrentPage] = useState(1);
+
+    /**
+     * Chart year window — a view-only range over the chart's year (y) axis.
+     * Ephemeral: it only reframes the charts (and the WYSIWYG figure export),
+     * never the table or the CSV "Data download". `null` means "full span".
+     * See docs/context/prevalence-visualization.md (monorepo root).
+     */
+    const [chartYearRange, setChartYearRange] = useState<
+        [number, number] | null
+    >(null);
+
+    /** Distinct years the selected microorganism actually has data for. */
+    const microYears = useMemo(() => {
+        const years = prevalenceData
+            .filter(
+                (entry) => entry.microorganism === selectedChartMicroorganism
+            )
+            .map((entry) => entry.samplingYear)
+            .filter(Number.isFinite);
+        return Array.from(new Set(years)).sort((a, b) => a - b);
+    }, [prevalenceData, selectedChartMicroorganism]);
+
+    const microYearMin = microYears[0];
+    const microYearMax = microYears[microYears.length - 1];
+
+    // The active window: an explicit selection, else the micro's full span.
+    const activeRange: [number, number] = chartYearRange ?? [
+        microYearMin,
+        microYearMax,
+    ];
+
+    // Reset the window to full span whenever the plotted microorganism or its
+    // year bounds change (microorganism switch or a fresh search). `null` = full.
+    useEffect(() => {
+        setChartYearRange(null);
+    }, [selectedChartMicroorganism, microYearMin, microYearMax]);
 
     const chartsPerPage = 2;
     const isSmallScreen = useMediaQuery("(max-width:1600px)");
@@ -107,32 +140,28 @@ const PrevalenceChart: React.FC = () => {
         )
     );
 
-    // ---- Year range fallback if context yearOptions empty ----
-    const yearRange = prevalenceData.map((entry) => entry.samplingYear);
-    yearMin = Math.min(...yearRange);
-    yearMax = Math.max(...yearRange);
+    const [rangeLo, rangeHi] = activeRange;
 
-    const yearOptionsForChart = Array.from(
-        { length: yearMax - yearMin + 1 },
-        (_, i) => yearMin + i
+    /**
+     * Years shown on the charts = the selected microorganism's years that fall
+     * inside the Chart year window. Intersection (not a contiguous fill), so a
+     * non-contiguous left-panel year filter is respected and years the micro has
+     * no data for drop out rather than showing as empty rows.
+     */
+    const yearsToShow = useMemo(
+        () => microYears.filter((y) => y >= rangeLo && y <= rangeHi),
+        [microYears, rangeLo, rangeHi]
     );
 
-    const allYearsForSlider =
-        yearOptions && yearOptions.length > 0
-            ? yearOptions
-            : yearOptionsForChart;
-
-    /** ✅ Years shown on charts */
-    const yearsToShow = useMemo(() => {
-        const base =
-            selectedYear && selectedYear.length > 0
-                ? selectedYear
-                : allYearsForSlider;
-        return [...base].filter(Number.isFinite).sort((a, b) => a - b);
-    }, [selectedYear, allYearsForSlider]);
-
+    // The prevalence-% axis rescales to the Chart year window: only CIs of years
+    // currently visible count. Zooming to low-prevalence years gives more detail,
+    // and because the PNG "Download chart" figure is WYSIWYG it captures this
+    // rescaled axis — while the CSV "Data download" stays full and unaffected.
+    const visibleYears = new Set(yearsToShow);
     const allCiMaxValues = Object.values(chartData).flatMap((yearData) =>
-        Object.values(yearData).map((data) => data.ciMax)
+        Object.entries(yearData)
+            .filter(([year]) => visibleYears.has(Number(year)))
+            .map(([, data]) => data.ciMax)
     );
     const maxCiPlus = Math.max(...allCiMaxValues);
     const xAxisMax = maxCiPlus > 25 ? 100 : 25;
@@ -265,6 +294,34 @@ const PrevalenceChart: React.FC = () => {
                         availableMicroorganisms={availableMicroorganisms}
                         setCurrentMicroorganism={setSelectedChartMicroorganism}
                     />
+                    {microYears.length >= 2 && (
+                        <Box sx={{ px: 1, mt: 1 }}>
+                            <Typography
+                                id="chart-year-range-label"
+                                variant="caption"
+                                component="label"
+                                sx={{
+                                    display: "block",
+                                    color: "text.secondary",
+                                    fontWeight: 500,
+                                }}
+                            >
+                                {t("Chart_Year_Range")}
+                            </Typography>
+                            <Slider
+                                size="small"
+                                value={activeRange}
+                                min={microYearMin}
+                                max={microYearMax}
+                                step={1}
+                                valueLabelDisplay="auto"
+                                aria-labelledby="chart-year-range-label"
+                                onChange={(_, value) =>
+                                    setChartYearRange(value as [number, number])
+                                }
+                            />
+                        </Box>
+                    )}
                 </Box>
             </Box>
 

--- a/src/app/prevalence/components/__tests__/PrevalenceChart.test.js
+++ b/src/app/prevalence/components/__tests__/PrevalenceChart.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { PrevalenceChart } from "../PrevalenceChart";
 import { usePrevalenceFilters } from "../PrevalenceDataContext";
 
@@ -15,9 +15,17 @@ jest.mock("../PrevalenceDataContext", () => ({
     usePrevalenceFilters: jest.fn(),
 }));
 
-// Mock react-chartjs-2 to avoid ref errors and chart rendering issues
+// Mock react-chartjs-2 to avoid canvas rendering in jsdom. The mock surfaces the
+// two things the Chart year window controls — the visible years (data.labels) and
+// the rescaled prevalence-% axis (options.scales.x.max) — so tests can observe them.
 jest.mock("react-chartjs-2", () => ({
-    Bar: () => <div data-testid="chart" />,
+    Bar: ({ data, options }) => (
+        <div
+            data-testid="chart"
+            data-labels={(data?.labels ?? []).join(",")}
+            data-xmax={options?.scales?.x?.max}
+        />
+    ),
 }));
 
 describe("PrevalenceChart Component", () => {
@@ -87,5 +95,155 @@ describe("PrevalenceChart Component", () => {
     it("displays charts when data is available", () => {
         render(<PrevalenceChart />);
         expect(screen.getAllByTestId("chart")).toHaveLength(1); // Checks if the mocked chart is rendered
+    });
+});
+
+describe("PrevalenceChart — Chart year window slider", () => {
+    // Build context data for a single microorganism spanning the given years.
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    const dataForYears = (years, micro = "E. Coli") =>
+        years.map((year) => ({
+            microorganism: micro,
+            sampleOrigin: "Sample Origin",
+            matrix: "Matrix",
+            samplingStage: "Stage",
+            samplingYear: year,
+            percentageOfPositive: 10,
+            ciMin: 5,
+            ciMax: 15,
+            numberOfSamples: 100,
+            numberOfPositive: 10,
+        }));
+
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    const mockContext = (overrides = {}) =>
+        usePrevalenceFilters.mockReturnValue({
+            prevalenceData: dataForYears([2020, 2021, 2022]),
+            loading: false,
+            prevalenceUpdateDate: null,
+            selectedYear: [],
+            setSelectedYear: jest.fn(),
+            yearOptions: [2020, 2021, 2022],
+            selectedChartMicroorganism: "E. Coli",
+            setSelectedChartMicroorganism: jest.fn(),
+            ...overrides,
+        });
+
+    it("renders a range slider spanning the selected microorganism's full year span by default", () => {
+        mockContext();
+        render(<PrevalenceChart />);
+
+        const thumbs = screen.getAllByRole("slider");
+        expect(thumbs).toHaveLength(2);
+        // Bounds are the micro's own min/max year
+        expect(thumbs[0]).toHaveAttribute("aria-valuemin", "2020");
+        expect(thumbs[0]).toHaveAttribute("aria-valuemax", "2022");
+        // Default window is the full span
+        expect(thumbs[0]).toHaveAttribute("aria-valuenow", "2020");
+        expect(thumbs[1]).toHaveAttribute("aria-valuenow", "2022");
+    });
+
+    it("hides the slider when the microorganism has only one year of data", () => {
+        mockContext({ prevalenceData: dataForYears([2022]) });
+        render(<PrevalenceChart />);
+
+        expect(screen.queryByRole("slider")).not.toBeInTheDocument();
+    });
+
+    it("shows a visible label describing what the slider does", () => {
+        mockContext();
+        render(<PrevalenceChart />);
+
+        const label = screen.getByText("Chart_Year_Range");
+        expect(label).toBeInTheDocument();
+        // The label is wired to the slider for assistive tech.
+        expect(screen.getAllByRole("slider")[0]).toHaveAccessibleName(
+            "Chart_Year_Range"
+        );
+    });
+
+    it("drops years outside the window from the rendered charts", () => {
+        mockContext();
+        render(<PrevalenceChart />);
+
+        // Full span initially: newest year first.
+        expect(screen.getByTestId("chart")).toHaveAttribute(
+            "data-labels",
+            "2022,2021,2020"
+        );
+
+        // Move the upper thumb down one year (2022 -> 2021).
+        const thumbs = screen.getAllByRole("slider");
+        fireEvent.change(thumbs[1], { target: { value: "2021" } });
+
+        expect(screen.getByTestId("chart")).toHaveAttribute(
+            "data-labels",
+            "2021,2020"
+        );
+    });
+
+    it("rescales the prevalence-% axis to only the years in the window", () => {
+        // 2022 has a wide confidence interval (>25%); the earlier years are low.
+        const data = dataForYears([2020, 2021, 2022]).map((entry) =>
+            entry.samplingYear === 2022 ? { ...entry, ciMax: 40 } : entry
+        );
+        mockContext({ prevalenceData: data });
+        render(<PrevalenceChart />);
+
+        // Full span includes the high-CI year -> wide axis.
+        expect(screen.getByTestId("chart")).toHaveAttribute("data-xmax", "100");
+
+        // Exclude 2022 -> all visible CIs are low -> axis tightens.
+        const thumbs = screen.getAllByRole("slider");
+        fireEvent.change(thumbs[1], { target: { value: "2021" } });
+
+        expect(screen.getByTestId("chart")).toHaveAttribute("data-xmax", "25");
+    });
+
+    it("does not mutate shared filter state when the window changes (view-only)", () => {
+        const setSelectedYear = jest.fn();
+        const setSelectedChartMicroorganism = jest.fn();
+        mockContext({ setSelectedYear, setSelectedChartMicroorganism });
+        render(<PrevalenceChart />);
+
+        const thumbs = screen.getAllByRole("slider");
+        fireEvent.change(thumbs[1], { target: { value: "2021" } });
+
+        expect(setSelectedYear).not.toHaveBeenCalled();
+        expect(setSelectedChartMicroorganism).not.toHaveBeenCalled();
+    });
+
+    it("resets the window to full span when the microorganism changes", () => {
+        const data = [
+            ...dataForYears([2020, 2021, 2022], "E. Coli"),
+            ...dataForYears([2023, 2024, 2025], "Salmonella"),
+        ];
+        mockContext({
+            prevalenceData: data,
+            selectedChartMicroorganism: "E. Coli",
+        });
+        const { rerender } = render(<PrevalenceChart />);
+
+        // Narrow the E. Coli window.
+        fireEvent.change(screen.getAllByRole("slider")[1], {
+            target: { value: "2021" },
+        });
+        expect(screen.getAllByRole("slider")[1]).toHaveAttribute(
+            "aria-valuenow",
+            "2021"
+        );
+
+        // Switch microorganism -> window must snap back to the new micro's span.
+        mockContext({
+            prevalenceData: data,
+            selectedChartMicroorganism: "Salmonella",
+        });
+        rerender(<PrevalenceChart />);
+
+        const thumbs = screen.getAllByRole("slider");
+        expect(thumbs[0]).toHaveAttribute("aria-valuemin", "2023");
+        expect(thumbs[1]).toHaveAttribute("aria-valuemax", "2025");
+        expect(thumbs[0]).toHaveAttribute("aria-valuenow", "2023");
+        expect(thumbs[1]).toHaveAttribute("aria-valuenow", "2025");
     });
 });

--- a/src/locales/de/PrevalencePage.json
+++ b/src/locales/de/PrevalencePage.json
@@ -72,6 +72,7 @@
   "Year": "Erhebungsjahr",
   "Prevalence %": "Prävalenz (%)",
   "Select_Microorganism": "Auswahl Mikroorganismus",
+  "Chart_Year_Range": "Angezeigter Jahresbereich",
   "dataGridnoRowsLabel": "Keine Daten vorhanden",
   "dataGridnoResultsOverlayLabel": "Keine Ergebnisse gefunden",
   "dataGridcolumnHeaderSortIconLabel": "Sortierung",

--- a/src/locales/en/PrevalencePage.json
+++ b/src/locales/en/PrevalencePage.json
@@ -83,6 +83,7 @@
   "dataGridcolumnMenuManageColumns": "Manage columns",
   "PREVALENCE_INFORMATION": "Instructions",
   "Select_Microorganism": "Select Microorganism",
+  "Chart_Year_Range": "Displayed year range",
 
   "REQUIRED_FIELD_INDICATOR": "Fields marked with a star (*) are required. Please select at least one option from each required field to activate the search button."
 }


### PR DESCRIPTION
Add a labelled MUI range slider between the microorganism selector and the prevalence charts to narrow the displayed year (y-axis) range. It is view-only: it reframes the charts and the WYSIWYG chart PNG, but never the table or the CSV data download. Bounds track the selected microorganism's own year span and reset on microorganism switch / new search; the x-axis rescales to the visible years. Hidden when a microorganism has fewer than two years of data.

Adds Chart_Year_Range label (EN/DE) and tests covering the six behaviours.