### PR TITLE
fix: use React 18 createRoot API instead of deprecated ReactDOM.render

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,7 +5,7 @@ import React, {
     useState,
     forwardRef,
 } from "react";
-import * as ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import {
     StyledEngineProvider,
     ThemeProvider,
@@ -70,13 +70,17 @@ const App = (): ReactElement => {
     );
 };
 
-ReactDOM.render(
+const container = document.querySelector("#application");
+if (!container) {
+    throw new Error("Root container '#application' not found");
+}
+const root = createRoot(container);
+root.render(
     <StyledEngineProvider injectFirst>
         <ThemeProvider theme={theme}>
             <Suspense fallback={<LoadingProcessComponent />}>
                 <App />
             </Suspense>
         </ThemeProvider>
-    </StyledEngineProvider>,
-    document.querySelector("#application")
+    </StyledEngineProvider>
 );


### PR DESCRIPTION
Switches the app entry point in App.tsx from ReactDOM.render to createRoot from react-dom/client, removing the React 18 deprecation warning and enabling true React 18 (concurrent) mode instead of the React 17 compatibility fallback.