### PR TITLE
fix(antibiotic): repair Kombinationen Select All when >4 combos available

### DIFF
--- a/src/app/antibiotic_resistance/pages/SubstanceDetail.tsx
+++ b/src/app/antibiotic_resistance/pages/SubstanceDetail.tsx
@@ -1372,6 +1372,23 @@ export const SubstanceDetail: React.FC<{
             .filter(Boolean);
     }, [selectedCombinations, comboLabelMap]);
 
+    //  The chart can display at most MAX_COMBINATIONS combos, so "Select All" is
+    //  capped at that many. Measure the "all selected" state against the cap (not
+    //  the raw available count) so the toggle, checkbox and label work when more
+    //  than MAX_COMBINATIONS combinations are available.
+    const MAX_COMBINATIONS = 4;
+    const maxSelectableCombinations = Math.min(
+        MAX_COMBINATIONS,
+        availableCombinations.length
+    );
+    const allCombinationsSelected =
+        availableCombinations.length > 0 &&
+        selectedCombinations.length === maxSelectableCombinations;
+    //  When the cap actually limits the selection, say so ("Select first 4");
+    //  otherwise it really is a plain select-all.
+    const combinationsAreCapped =
+        availableCombinations.length > MAX_COMBINATIONS;
+
     return (
         <>
             <style>{menuItemTextStyle}</style>
@@ -1514,14 +1531,12 @@ export const SubstanceDetail: React.FC<{
                                         let nextCombos: string[] = v;
 
                                         if (v.includes("all")) {
-                                            nextCombos =
-                                                selectedCombinations.length ===
-                                                availableCombinations.length
-                                                    ? []
-                                                    : availableCombinations.slice(
-                                                          0,
-                                                          4
-                                                      );
+                                            nextCombos = allCombinationsSelected
+                                                ? []
+                                                : availableCombinations.slice(
+                                                      0,
+                                                      maxSelectableCombinations
+                                                  );
                                             setSelectedCombinations(nextCombos);
                                         } else if (v.length > 4) {
                                             setMaxComboDialogOpen(true);
@@ -1555,23 +1570,26 @@ export const SubstanceDetail: React.FC<{
                                 >
                                     <MenuItem value="all">
                                         <Checkbox
-                                            checked={
-                                                selectedCombinations.length ===
-                                                availableCombinations.length
-                                            }
+                                            checked={allCombinationsSelected}
                                             indeterminate={
                                                 selectedCombinations.length >
                                                     0 &&
-                                                selectedCombinations.length <
-                                                    availableCombinations.length
+                                                !allCombinationsSelected
                                             }
                                         />
                                         <ListItemText
                                             primary={
-                                                selectedCombinations.length ===
-                                                availableCombinations.length
-                                                    ? t("DESELECT_ALL") ||
-                                                      "Deselect All"
+                                                allCombinationsSelected
+                                                    ? combinationsAreCapped
+                                                        ? t(
+                                                              "DESELECT_ALL_COMBINATIONS"
+                                                          ) || "Deselect all"
+                                                        : t("DESELECT_ALL") ||
+                                                          "Deselect All"
+                                                    : combinationsAreCapped
+                                                    ? t(
+                                                          "SELECT_ALL_COMBINATIONS"
+                                                      ) || "Select first 4"
                                                     : t("SELECT_ALL") ||
                                                       "Select All"
                                             }

--- a/src/locales/de/Antibiotic.json
+++ b/src/locales/de/Antibiotic.json
@@ -34,6 +34,8 @@
 
   "SELECT_ALL": "Alle auswählen",
   "DESELECT_ALL": " Alle abwählen",
+  "SELECT_ALL_COMBINATIONS": "Erste 4 auswählen",
+  "DESELECT_ALL_COMBINATIONS": "Alle abwählen",
   "ALL_VALUES": "Alle Werte",
   "anzahlResistenterIsolate": "anzahlResistenterIsolate",
   "minKonfidenzintervall": "minKonfidenzintervall",

--- a/src/locales/en/Antibiotic.json
+++ b/src/locales/en/Antibiotic.json
@@ -29,6 +29,8 @@
   "MoreInfoOnMulti": "More information about the Multiple Resistance Graph",
   "SELECT_ALL": "Select All",
   "DESELECT_ALL": "Deselect All",
+  "SELECT_ALL_COMBINATIONS": "Select first 4",
+  "DESELECT_ALL_COMBINATIONS": "Deselect all",
   "ALL_VALUES": "All values",
   "ComingSoon": "Coming soon...",
   "RESET_FILTERS": "Reset Filters",


### PR DESCRIPTION
## Problem

On the Antibiotic Resistance → Substance Graph view, the **Kombinationen** dropdown offers a "Select All" option, but it doesn't work when more than 4 combinations are available (the common case).

The dropdown caps selection at **4** combinations (the chart can display at most 4). However, the Select All toggle, checkbox and label all compared `selectedCombinations.length === availableCombinations.length`. With more than 4 combinations available that equality can never be true, so:

- the toggle could never reach the "deselect" branch — clicking just re-selected the first 4 and never cleared the selection;
- the label stayed "Select All" forever, never flipping to "Deselect All";
- the checkbox never showed checked and stayed stuck on the indeterminate dash.

## Fix

Measure the "all selected" state against the **effective cap** (`min(4, availableCombinations.length)`) instead of the raw available count. The toggle, checkbox `checked`/`indeterminate`, and label now all use this derived state.

Added combinations-specific locale strings (EN + DE) shown only when the cap actually applies (more than 4 available); otherwise the label falls back to the shared Select All / Deselect All:

| Key | EN | DE |
|---|---|---|
| `SELECT_ALL_COMBINATIONS` | Select first 4 | Erste 4 auswählen |
| `DESELECT_ALL_COMBINATIONS` | Deselect all | Alle abwählen |

## Testing

- `npx tsc --noEmit` passes clean
- Pre-commit hooks (lint-staged + jest) passed
- Not yet manually exercised in-browser