### PR TITLE
feat(antibiotic): add ESBL/AmpC E. coli entry to AMR sidebar

### DIFF
--- a/src/app/antibiotic_resistance/pages/AntibioticResistancePage.component.tsx
+++ b/src/app/antibiotic_resistance/pages/AntibioticResistancePage.component.tsx
@@ -37,14 +37,24 @@ function decodeCompressedState(
 }
 
 // ---- Constants ----
+const ESBL_AMPC_E_COLI = "ESBL/AmpC E. coli";
+
 const ORGANISMS = [
     "E. coli",
+    ESBL_AMPC_E_COLI,
     "Campylobacter spp.",
     "Salmonella spp.",
     "MRSA",
     "STEC",
     "Enterococcus spp.",
 ];
+
+/**
+ * Organisms that are listed in the sidebar but have no resistance data in the
+ * CMS yet. Selecting one announces "Coming soon" rather than rendering charts
+ * that would resolve to an empty result set.
+ */
+const ORGANISMS_WITHOUT_DATA = new Set([ESBL_AMPC_E_COLI]);
 
 const italicWords: string[] = [
     "Salmonella",
@@ -143,6 +153,17 @@ function updateUrl(
     window.history.replaceState(null, "", `?${params.toString()}`);
 }
 
+/**
+ * Organisms without data have no charts to show, so any chart view requested
+ * via a deep link collapses back to the main view.
+ */
+function resolveView(
+    selectedOrg: string,
+    view: "main" | "trend" | "substance"
+): "main" | "trend" | "substance" {
+    return ORGANISMS_WITHOUT_DATA.has(selectedOrg) ? "main" : view;
+}
+
 function readStateFromUrl(): {
     selectedOrg: string;
     view: "main" | "trend" | "substance";
@@ -162,7 +183,10 @@ function readStateFromUrl(): {
             decoded.v === "substance"
                 ? decoded.v
                 : "substance";
-        return { selectedOrg: orgFromS, view: viewFromS };
+        return {
+            selectedOrg: orgFromS,
+            view: resolveView(orgFromS, viewFromS),
+        };
     }
 
     // Legacy simple params
@@ -173,7 +197,7 @@ function readStateFromUrl(): {
             : ORGANISMS[0];
     const view =
         (params.get("view") as "main" | "trend" | "substance") || "main";
-    return { selectedOrg, view };
+    return { selectedOrg, view: resolveView(selectedOrg, view) };
 }
 
 // ---- Breadcrumb ----
@@ -259,6 +283,7 @@ export function AntibioticResistancePageComponent(): JSX.Element {
     // Handlers
     const handleOrgSelect = (org: string): void => {
         setState({ selectedOrg: org, view: "main" });
+        if (ORGANISMS_WITHOUT_DATA.has(org)) setComingSoonOpen(true);
     };
 
     const handleTrendClick = (): void => {
@@ -491,98 +516,108 @@ export function AntibioticResistancePageComponent(): JSX.Element {
                             </aside>
 
                             <section className="abx-content">
-                                <div
-                                    className="image-box"
-                                    onClick={handleTrendClick}
-                                >
-                                    {trendTooltip && (
-                                        <Tooltip
-                                            title={trendTooltip}
-                                            placement="top"
-                                            arrow
+                                {!ORGANISMS_WITHOUT_DATA.has(selectedOrg) && (
+                                    <>
+                                        <div
+                                            className="image-box"
+                                            onClick={handleTrendClick}
                                         >
-                                            <IconButton
-                                                className="image-box-info"
-                                                size="small"
-                                                aria-label={t(
-                                                    "MoreInfoOnTrend"
-                                                )}
-                                                onClick={(e): void =>
-                                                    e.stopPropagation()
-                                                }
-                                            >
-                                                <InfoOutlinedIcon fontSize="small" />
-                                            </IconButton>
-                                        </Tooltip>
-                                    )}
-                                    <div className="image-label">
-                                        {t("Trend")}
-                                    </div>
-                                    <img src="/assets/trend.png" alt="Trend" />
-                                </div>
+                                            {trendTooltip && (
+                                                <Tooltip
+                                                    title={trendTooltip}
+                                                    placement="top"
+                                                    arrow
+                                                >
+                                                    <IconButton
+                                                        className="image-box-info"
+                                                        size="small"
+                                                        aria-label={t(
+                                                            "MoreInfoOnTrend"
+                                                        )}
+                                                        onClick={(e): void =>
+                                                            e.stopPropagation()
+                                                        }
+                                                    >
+                                                        <InfoOutlinedIcon fontSize="small" />
+                                                    </IconButton>
+                                                </Tooltip>
+                                            )}
+                                            <div className="image-label">
+                                                {t("Trend")}
+                                            </div>
+                                            <img
+                                                src="/assets/trend.png"
+                                                alt="Trend"
+                                            />
+                                        </div>
 
-                                <div
-                                    className="image-box"
-                                    onClick={handleSubstanceClick}
-                                >
-                                    {substanceTooltip && (
-                                        <Tooltip
-                                            title={substanceTooltip}
-                                            placement="top"
-                                            arrow
+                                        <div
+                                            className="image-box"
+                                            onClick={handleSubstanceClick}
                                         >
-                                            <IconButton
-                                                className="image-box-info"
-                                                size="small"
-                                                aria-label={t(
-                                                    "MoreInfoOnSubstance"
-                                                )}
-                                                onClick={(e): void =>
-                                                    e.stopPropagation()
-                                                }
-                                            >
-                                                <InfoOutlinedIcon fontSize="small" />
-                                            </IconButton>
-                                        </Tooltip>
-                                    )}
-                                    <div className="image-label">
-                                        {t("Substans")}
-                                    </div>
-                                    <img
-                                        src="/assets/substans.png"
-                                        alt="Substans"
-                                    />
-                                </div>
+                                            {substanceTooltip && (
+                                                <Tooltip
+                                                    title={substanceTooltip}
+                                                    placement="top"
+                                                    arrow
+                                                >
+                                                    <IconButton
+                                                        className="image-box-info"
+                                                        size="small"
+                                                        aria-label={t(
+                                                            "MoreInfoOnSubstance"
+                                                        )}
+                                                        onClick={(e): void =>
+                                                            e.stopPropagation()
+                                                        }
+                                                    >
+                                                        <InfoOutlinedIcon fontSize="small" />
+                                                    </IconButton>
+                                                </Tooltip>
+                                            )}
+                                            <div className="image-label">
+                                                {t("Substans")}
+                                            </div>
+                                            <img
+                                                src="/assets/substans.png"
+                                                alt="Substans"
+                                            />
+                                        </div>
 
-                                <div
-                                    className="image-box bottom"
-                                    onClick={handleComingSoon}
-                                >
-                                    {multiTooltip && (
-                                        <Tooltip
-                                            title={multiTooltip}
-                                            placement="top"
-                                            arrow
+                                        <div
+                                            className="image-box bottom"
+                                            onClick={handleComingSoon}
                                         >
-                                            <IconButton
-                                                className="image-box-info"
-                                                size="small"
-                                                aria-label={t(
-                                                    "MoreInfoOnMulti"
-                                                )}
-                                                onClick={(e): void =>
-                                                    e.stopPropagation()
-                                                }
-                                            >
-                                                <InfoOutlinedIcon fontSize="small" />
-                                            </IconButton>
-                                        </Tooltip>
-                                    )}
-                                    <div className="image-label">
-                                        {t("Multi")}
-                                    </div>
-                                    <img src="/assets/multi.png" alt="Multi" />
-                                </div>
+                                            {multiTooltip && (
+                                                <Tooltip
+                                                    title={multiTooltip}
+                                                    placement="top"
+                                                    arrow
+                                                >
+                                                    <IconButton
+                                                        className="image-box-info"
+                                                        size="small"
+                                                        aria-label={t(
+                                                            "MoreInfoOnMulti"
+                                                        )}
+                                                        onClick={(e): void =>
+                                                            e.stopPropagation()
+                                                        }
+                                                    >
+                                                        <InfoOutlinedIcon fontSize="small" />
+                                                    </IconButton>
+                                                </Tooltip>
+                                            )}
+                                            <div className="image-label">
+                                                {t("Multi")}
+                                            </div>
+                                            <img
+                                                src="/assets/multi.png"
+                                                alt="Multi"
+                                            />
+                                        </div>
+                                    </>
+                                )}
                             </section>
                         </div>
                     </>

--- a/src/app/antibiotic_resistance/pages/__tests__/AntibioticResistancePage.component.test.tsx
+++ b/src/app/antibiotic_resistance/pages/__tests__/AntibioticResistancePage.component.test.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import {
+    AntibioticResistancePageComponent,
+    FormattedMicroorganismName,
+} from "../AntibioticResistancePage.component";
+
+jest.mock("../../../shared/components/layout/PageLayoutComponent", () => ({
+    PageLayoutComponent: ({ children }: { children: React.ReactNode }) => (
+        <div>{children}</div>
+    ),
+}));
+
+jest.mock("../amrPageUseCase", () => ({
+    useAmrPageTooltips: () => ({
+        trendTooltip: "",
+        substanceTooltip: "",
+        multiTooltip: "",
+    }),
+}));
+
+jest.mock("../TrendDetails", () => ({
+    TrendDetails: () => <div data-testid="trend-details" />,
+}));
+
+jest.mock("../SubstanceDetail", () => ({
+    SubstanceDetail: () => <div data-testid="substance-detail" />,
+}));
+
+jest.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const ESBL = "ESBL/AmpC E. coli";
+
+/** Find a sidebar entry by its visible label, ignoring markup/whitespace. */
+function navItem(label: string): HTMLElement | undefined {
+    return Array.from(
+        document.querySelectorAll<HTMLElement>(".abx-nav-item")
+    ).find((li) => li.textContent?.replace(/\s+/g, " ").trim() === label);
+}
+
+function renderPage(search = ""): void {
+    window.history.replaceState(null, "", `/${search}`);
+    render(
+        <MemoryRouter>
+            <AntibioticResistancePageComponent />
+        </MemoryRouter>
+    );
+}
+
+beforeAll(() => {
+    window.scrollTo = jest.fn();
+});
+
+describe("AntibioticResistancePage sidebar", () => {
+    it("offers ESBL/AmpC E. coli as a selectable organism", () => {
+        renderPage();
+
+        const item = navItem(ESBL);
+        expect(item).toBeDefined();
+
+        fireEvent.click(item as HTMLElement);
+
+        expect(navItem(ESBL)).toHaveClass("abx-active");
+    });
+
+    it("announces Coming soon instead of empty charts when ESBL/AmpC E. coli is selected", () => {
+        renderPage();
+
+        fireEvent.click(navItem(ESBL) as HTMLElement);
+
+        expect(screen.getByText("ComingSoon")).toBeInTheDocument();
+        expect(screen.queryByAltText("Trend")).not.toBeInTheDocument();
+        expect(screen.queryByAltText("Substans")).not.toBeInTheDocument();
+    });
+
+    it("still offers the chart tiles for organisms that have data", () => {
+        renderPage();
+
+        expect(screen.getByAltText("Trend")).toBeInTheDocument();
+        expect(screen.getByAltText("Substans")).toBeInTheDocument();
+        expect(screen.queryByText("ComingSoon")).not.toBeInTheDocument();
+    });
+});
+
+describe("AntibioticResistancePage deep links", () => {
+    it("restores an ESBL/AmpC E. coli selection from the URL", () => {
+        renderPage("?microorganism=ESBL%2FAmpC%20E.%20coli&view=main");
+
+        expect(navItem(ESBL)).toHaveClass("abx-active");
+    });
+
+    it("refuses to open a chart view for an organism that has no data", () => {
+        renderPage("?microorganism=ESBL%2FAmpC%20E.%20coli&view=trend");
+
+        expect(screen.queryByTestId("trend-details")).not.toBeInTheDocument();
+        expect(navItem(ESBL)).toHaveClass("abx-active");
+    });
+
+    it("still honours a chart deep link for an organism that has data", () => {
+        renderPage("?microorganism=E.%20coli&view=trend");
+
+        expect(screen.getByTestId("trend-details")).toBeInTheDocument();
+    });
+});
+
+describe("FormattedMicroorganismName", () => {
+    it("italicises only the species part of ESBL/AmpC E. coli", () => {
+        const { container } = render(
+            <FormattedMicroorganismName microName={ESBL} />
+        );
+
+        const italicised = Array.from(container.querySelectorAll("i")).map(
+            (el) => el.textContent
+        );
+        expect(italicised).toEqual(["E.", "coli"]);
+
+        // The resistance-mechanism prefix stays upright.
+        expect(container.textContent).toContain("ESBL/AmpC");
+    });
+});

--- a/src/app/antibiotic_resistance/pages/__tests__/resistanceHelpers.test.ts
+++ b/src/app/antibiotic_resistance/pages/__tests__/resistanceHelpers.test.ts
@@ -1,0 +1,11 @@
+import { buildMicroorganismFilter } from "../resistanceHelpers";
+
+describe("buildMicroorganismFilter", () => {
+    it("matches ESBL/AmpC E. coli by substring so it resolves in both locales", () => {
+        // The DB name is translated ("ESBL/AmpC-producing E. coli" vs
+        // "ESBL/AmpC-bildende E. coli"), so only the "ESBL" stem is stable.
+        expect(buildMicroorganismFilter("ESBL/AmpC E. coli")).toBe(
+            "&filters[microorganism][name][$containsi]=ESBL"
+        );
+    });
+});

--- a/src/app/antibiotic_resistance/pages/resistanceHelpers.ts
+++ b/src/app/antibiotic_resistance/pages/resistanceHelpers.ts
@@ -130,12 +130,28 @@ export function buildNameToDocIdMap(
 const CONTAINS_FILTER_ORGANISMS = new Set(["MRSA", "STEC"]);
 
 /**
+ * Organisms matched by a bare substring of their DB name rather than by the
+ * "(ABBREV)" pattern above. "ESBL/AmpC E. coli" is stored with a translated
+ * qualifier ("ESBL/AmpC-producing E. coli" / "ESBL/AmpC-bildende E. coli"),
+ * so the "ESBL" stem is the only locale-stable part of the name.
+ */
+const SUBSTRING_FILTER_ORGANISMS: Record<string, string> = {
+    "ESBL/AmpC E. coli": "ESBL",
+};
+
+/**
  * Returns the Strapi filter query segment for a microorganism name.
  * Uses $containsi for organisms whose UI name is an abbreviation that
  * appears inside the full DB name (e.g. "(MRSA)", "(STEC)").
  * Falls back to exact $eq match for all other organisms.
  */
 export function buildMicroorganismFilter(microorganism: string): string {
+    const substringMatch = SUBSTRING_FILTER_ORGANISMS[microorganism];
+    if (substringMatch) {
+        return `&filters[microorganism][name][$containsi]=${encodeURIComponent(
+            substringMatch
+        )}`;
+    }
     if (CONTAINS_FILTER_ORGANISMS.has(microorganism)) {
         return `&filters[microorganism][name][$containsi]=${encodeURIComponent(
             `(${microorganism})`


### PR DESCRIPTION
ZN-1757

Add ESBL/AmpC E. coli to the microorganism sidebar on the antibiotic resistance page, listed next to E. coli. The label is a Latin/abbreviation string shown identically in EN and DE; FormattedMicroorganismName already italicizes the species part and leaves the ESBL/AmpC prefix upright.

No resistance data exists for this organism in the CMS yet, so selecting it opens the existing "Coming soon" dialog (translated in both locales) and the Trend/Substance/Multi tiles are suppressed rather than rendering charts that would resolve to an empty result set.

Adding the organism to ORGANISMS also whitelists it for the ?microorganism= URL param, which let a deep link such as ?microorganism=ESBL/AmpC E. coli &view=trend open a chart view for an organism with no data. Clamp the view back to "main" for such organisms in readStateFromUrl, covering both the legacy params and the compressed ?s= deep link.

Map the organism to a $containsi=ESBL Strapi filter. Its DB name carries a translated qualifier ("ESBL/AmpC-producing" / "ESBL/AmpC-bildende"), so the ESBL stem is the only locale-stable part to match on. The filter is inert until the data lands.

Add tests covering the filter mapping, sidebar rendering and selection, the Coming soon placeholder, deep-link view clamping (and that organisms with data still honour chart deep links), and species italicization.