### PR TITLE
feat(seo): resolve per-route title, description and canonical at runtime

### DIFF
--- a/src/app/shared/infrastructure/router/Body-Router.component.tsx
+++ b/src/app/shared/infrastructure/router/Body-Router.component.tsx
@@ -13,12 +13,17 @@ import { AntimicrobialPageComponent } from "../../../antimicrobial/pages/Antimic
 import { MicrobialCountsPageComponent } from "../../../microbial_counts/pages/MicrobialCountsPage.component";
 
 import { pageRoute } from "./routes";
+import { useSeo } from "../../seo/useSeo";
 
 function ErrorPage(): JSX.Element {
     return <ErrorPageComponent errorStatus={404} />;
 }
 
 export function BodyRouterComponent(): JSX.Element {
+    // Mounted here, inside the router but above the Switch, so it runs for every
+    // route -- including any added later without a matching wiring step.
+    useSeo();
+
     return (
         <Switch>
             <Route

--- a/src/app/shared/seo/__tests__/useSeo.test.tsx
+++ b/src/app/shared/seo/__tests__/useSeo.test.tsx
@@ -1,0 +1,209 @@
+import React, { ReactNode } from "react";
+import { act, renderHook } from "@testing-library/react";
+// eslint-disable-next-line import/named
+import i18next, { i18n as I18nInstance } from "i18next";
+import { I18nextProvider, initReactI18next } from "react-i18next";
+import { MemoryRouter } from "react-router-dom";
+import { pageRoute } from "../../infrastructure/router/routes";
+import seoDe from "../../../../locales/de/Seo.json";
+import seoEn from "../../../../locales/en/Seo.json";
+import { useSeo } from "../useSeo";
+
+/**
+ * A real i18next instance seeded from the real locale files -- only the HTTP
+ * backend is swapped for in-memory resources. Nothing about the hook itself is
+ * mocked, so these tests exercise the same path the browser does.
+ */
+async function createI18n(language: string): Promise<I18nInstance> {
+    const instance = i18next.createInstance();
+    await instance.use(initReactI18next).init({
+        lng: language,
+        fallbackLng: "de",
+        ns: ["Seo"],
+        defaultNS: "Seo",
+        resources: { de: { Seo: seoDe }, en: { Seo: seoEn } },
+        interpolation: { escapeValue: false },
+    });
+    return instance;
+}
+
+/** Mirrors the static tags src/index.html ships, so "updates in place rather
+ *  than duplicating" is tested against the markup that really exists. */
+function seedStaticHead(): void {
+    document.head.innerHTML = `
+        <title>ZooNotify — Zoonosen-Surveillancedaten des BfR</title>
+        <meta name="description" content="static baseline" />
+        <meta property="og:title" content="static baseline" />
+        <meta property="og:description" content="static baseline" />
+        <meta property="og:url" content="https://zoonotify.bfr.berlin/" />
+        <link rel="canonical" href="https://zoonotify.bfr.berlin/" />
+        <link rel="alternate" hreflang="de" href="https://zoonotify.bfr.berlin/?lang=de" />
+        <link rel="alternate" hreflang="en" href="https://zoonotify.bfr.berlin/?lang=en" />
+        <link rel="alternate" hreflang="x-default" href="https://zoonotify.bfr.berlin/" />
+    `;
+    document.documentElement.lang = "de";
+}
+
+async function renderAt(
+    path: string,
+    language = "de"
+): Promise<{ i18n: I18nInstance }> {
+    const instance = await createI18n(language);
+    const wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+        <I18nextProvider i18n={instance}>
+            <MemoryRouter initialEntries={[path]}>{children}</MemoryRouter>
+        </I18nextProvider>
+    );
+    renderHook(() => useSeo(), { wrapper });
+    return { i18n: instance };
+}
+
+const metaContent = (selector: string): string | null =>
+    document.head.querySelector(selector)?.getAttribute("content") ?? null;
+
+const linkHref = (selector: string): string | null =>
+    document.head.querySelector(selector)?.getAttribute("href") ?? null;
+
+beforeEach(() => {
+    seedStaticHead();
+});
+
+describe("useSeo", () => {
+    it("gives a route its own title instead of the site-wide default", async () => {
+        await renderAt("/prevalence");
+
+        expect(document.title).toContain("Prävalenz");
+    });
+
+    it("gives every route its own title and description, so no two pages look alike in search results", async () => {
+        const resolved = [];
+
+        for (const path of Object.values(pageRoute)) {
+            seedStaticHead();
+            // eslint-disable-next-line no-await-in-loop
+            await renderAt(path);
+            resolved.push({
+                path,
+                title: document.title,
+                description: metaContent('meta[name="description"]'),
+            });
+        }
+
+        resolved.forEach(({ path, title, description }) => {
+            expect(`${path}: ${title}`).not.toContain(".title");
+            expect(`${path}: ${description}`).not.toContain(".description");
+            expect(`${path}: ${description}`).not.toContain("static baseline");
+        });
+
+        expect(new Set(resolved.map((entry) => entry.title)).size).toBe(
+            resolved.length
+        );
+        expect(new Set(resolved.map((entry) => entry.description)).size).toBe(
+            resolved.length
+        );
+    });
+
+    it("serves the metadata in the active language", async () => {
+        await renderAt("/prevalence", "en");
+
+        expect(document.title).toContain("Prevalence");
+        expect(metaContent('meta[name="description"]')).toContain(
+            "zoonotic pathogens"
+        );
+    });
+
+    it("declares the active language on the document, not a hardcoded one", async () => {
+        await renderAt("/prevalence", "en");
+
+        expect(document.documentElement.lang).toBe("en");
+    });
+
+    it("re-resolves the head when the language changes mid-session", async () => {
+        const { i18n } = await renderAt("/prevalence", "de");
+        expect(document.title).toContain("Prävalenz");
+
+        await act(async () => {
+            await i18n.changeLanguage("en");
+        });
+
+        expect(document.title).toContain("Prevalence");
+        expect(document.documentElement.lang).toBe("en");
+    });
+
+    it("points the canonical at this route in this language", async () => {
+        await renderAt("/prevalence", "en");
+
+        expect(linkHref('link[rel="canonical"]')).toBe(
+            "http://localhost/prevalence?lang=en"
+        );
+    });
+
+    it("keeps filter state out of the canonical, so filter combinations cannot mint endless URLs", async () => {
+        await renderAt(
+            "/antibiotic-resistance?microorganism=E.coli&view=trend&s=eJyrVg&lang=de"
+        );
+
+        expect(linkHref('link[rel="canonical"]')).toBe(
+            "http://localhost/antibiotic-resistance?lang=de"
+        );
+    });
+
+    it("cross-links the route's translations so they are not treated as duplicates", async () => {
+        await renderAt("/evaluations", "de");
+
+        expect(linkHref('link[rel="alternate"][hreflang="de"]')).toBe(
+            "http://localhost/evaluations?lang=de"
+        );
+        expect(linkHref('link[rel="alternate"][hreflang="en"]')).toBe(
+            "http://localhost/evaluations?lang=en"
+        );
+        expect(linkHref('link[rel="alternate"][hreflang="x-default"]')).toBe(
+            "http://localhost/evaluations"
+        );
+    });
+
+    it("keeps unknown paths out of the index instead of advertising a 404", async () => {
+        await renderAt("/no-such-page");
+
+        expect(metaContent('meta[name="robots"]')).toContain("noindex");
+    });
+
+    it("marks known routes as indexable, so a 404 visit cannot poison the next page", async () => {
+        await renderAt("/no-such-page");
+        expect(metaContent('meta[name="robots"]')).toContain("noindex");
+
+        await renderAt("/prevalence");
+
+        expect(metaContent('meta[name="robots"]')).not.toContain("noindex");
+    });
+
+    it("updates the static tags from index.html in place rather than appending a second copy", async () => {
+        await renderAt("/prevalence", "en");
+
+        expect(
+            document.head.querySelectorAll('meta[name="description"]')
+        ).toHaveLength(1);
+        expect(
+            document.head.querySelectorAll('link[rel="canonical"]')
+        ).toHaveLength(1);
+        expect(
+            document.head.querySelectorAll(
+                'link[rel="alternate"][hreflang="de"]'
+            )
+        ).toHaveLength(1);
+    });
+
+    it("keeps the Open Graph tags in step with the route, so shared links preview correctly", async () => {
+        await renderAt("/prevalence", "en");
+
+        expect(metaContent('meta[property="og:title"]')).toContain(
+            "Prevalence"
+        );
+        expect(metaContent('meta[property="og:description"]')).toContain(
+            "zoonotic pathogens"
+        );
+        expect(metaContent('meta[property="og:url"]')).toBe(
+            "http://localhost/prevalence?lang=en"
+        );
+    });
+});

--- a/src/app/shared/seo/seo.model.ts
+++ b/src/app/shared/seo/seo.model.ts
@@ -1,0 +1,73 @@
+import { pageRoute } from "../infrastructure/router/routes";
+
+/** The locales the CMS publishes. Mirrors `languages` in src/i18n.ts. */
+export const SEO_LANGUAGES = ["de", "en"] as const;
+export type SeoLanguage = (typeof SEO_LANGUAGES)[number];
+
+/**
+ * i18next hands back tags like "de-DE"; our URLs and the `lang` attribute only
+ * ever carry the bare language. Anything unrecognised falls back to the same
+ * default as i18n's fallbackLng.
+ */
+export function normalizeLanguage(
+    value: string | undefined | null
+): SeoLanguage {
+    const base = (value || "").split("-")[0].toLowerCase();
+    return (SEO_LANGUAGES as readonly string[]).includes(base)
+        ? (base as SeoLanguage)
+        : "de";
+}
+
+export type SeoRoute = {
+    /** Route path as declared in `pageRoute`. */
+    readonly path: string;
+    /** Key in the Seo i18n namespace: `<key>.title` and `<key>.description`. */
+    readonly key: string;
+};
+
+/**
+ * Route -> metadata. Every entry in `pageRoute` must appear here; the test
+ * suite iterates the routing table and fails if any route resolves no copy.
+ */
+export const SEO_ROUTES: readonly SeoRoute[] = [
+    { path: pageRoute.homePagePath, key: "home" },
+    { path: pageRoute.linkPagePath, key: "links" },
+    { path: pageRoute.infoPagePath, key: "explanations" },
+    { path: pageRoute.evaluationsPagePath, key: "evaluations" },
+    { path: pageRoute.dpdPagePath, key: "dataProtection" },
+    { path: pageRoute.prevalencePagePath, key: "prevalence" },
+    { path: pageRoute.antimicrobialPagePath, key: "antimicrobial" },
+    {
+        path: pageRoute.antibioticResistancePagePath,
+        key: "antibioticResistance",
+    },
+    { path: pageRoute.microbialCountsPagePath, key: "microbialCounts" },
+];
+
+/**
+ * Resolves a pathname to its SEO entry, or null for an unknown path.
+ *
+ * The home route is matched exactly: as "/" it is a prefix of every other
+ * route, so a prefix match would claim them all.
+ */
+export function matchSeoRoute(pathname: string): SeoRoute | null {
+    const normalized =
+        pathname.length > 1 && pathname.endsWith("/")
+            ? pathname.slice(0, -1)
+            : pathname;
+
+    if (normalized === pageRoute.homePagePath) {
+        return (
+            SEO_ROUTES.find((route) => route.path === pageRoute.homePagePath) ??
+            null
+        );
+    }
+
+    return (
+        SEO_ROUTES.find(
+            (route) =>
+                route.path !== pageRoute.homePagePath &&
+                normalized.startsWith(route.path)
+        ) ?? null
+    );
+}

--- a/src/app/shared/seo/useSeo.ts
+++ b/src/app/shared/seo/useSeo.ts
@@ -1,0 +1,114 @@
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { useLocation } from "react-router-dom";
+import {
+    matchSeoRoute,
+    normalizeLanguage,
+    SEO_LANGUAGES,
+    SeoLanguage,
+} from "./seo.model";
+
+/**
+ * Marks elements this hook added, distinguishing them from the static baseline
+ * in src/index.html when inspecting the head. Tags the static markup already
+ * carries are updated in place rather than duplicated.
+ */
+const MANAGED_ATTR = "data-seo-managed";
+
+const OG_LOCALE: Record<SeoLanguage, string> = { de: "de_DE", en: "en_GB" };
+
+function upsert<E extends HTMLElement>(selector: string, create: () => E): E {
+    const existing = document.head.querySelector<E>(selector);
+    if (existing) return existing;
+    const element = create();
+    element.setAttribute(MANAGED_ATTR, "true");
+    document.head.appendChild(element);
+    return element;
+}
+
+function setMeta(
+    keyAttr: "name" | "property",
+    key: string,
+    content: string
+): void {
+    const element = upsert<HTMLMetaElement>(`meta[${keyAttr}="${key}"]`, () => {
+        const meta = document.createElement("meta");
+        meta.setAttribute(keyAttr, key);
+        return meta;
+    });
+    element.setAttribute("content", content);
+}
+
+function setLink(rel: string, href: string, hreflang?: string): void {
+    const selector = hreflang
+        ? `link[rel="${rel}"][hreflang="${hreflang}"]`
+        : `link[rel="${rel}"]`;
+    const element = upsert<HTMLLinkElement>(selector, () => {
+        const link = document.createElement("link");
+        link.setAttribute("rel", rel);
+        if (hreflang) link.setAttribute("hreflang", hreflang);
+        return link;
+    });
+    element.setAttribute("href", href);
+}
+
+/**
+ * Canonical deliberately carries ONLY the language parameter. The data pages
+ * push filter state (microorganism, view, s, ...) into the query string, and
+ * folding that in would mint a fresh canonical URL for every filter combination
+ * a crawler stumbles across.
+ */
+function canonicalUrl(pathname: string, language: SeoLanguage): string {
+    return `${window.location.origin}${pathname}?lang=${language}`;
+}
+
+/**
+ * Keeps the document head in step with the active route and language.
+ *
+ * Mounted once inside the router rather than per page, so every route gets
+ * metadata and the rules live in one place.
+ */
+export function useSeo(): void {
+    const { t, i18n } = useTranslation(["Seo"]);
+    const { pathname } = useLocation();
+
+    useEffect(() => {
+        const language = normalizeLanguage(i18n.language);
+        document.documentElement.lang = language;
+
+        const route = matchSeoRoute(pathname);
+
+        // Unknown path -> the 404 page. Keep it out of the index entirely, but
+        // still let crawlers follow the navigation away from it.
+        if (!route) {
+            setMeta("name", "robots", "noindex, follow");
+            document.title = `${t("notFound.title")} — ZooNotify`;
+            setMeta("name", "description", t("notFound.description"));
+            return;
+        }
+        setMeta("name", "robots", "index, follow");
+
+        const title = t(`${route.key}.title`);
+        // The home title already names the site; suffixing it would stutter.
+        document.title = route.key === "home" ? title : `${title} — ZooNotify`;
+        setMeta("name", "description", t(`${route.key}.description`));
+        setLink("canonical", canonicalUrl(pathname, language));
+        SEO_LANGUAGES.forEach((alternate) => {
+            setLink("alternate", canonicalUrl(pathname, alternate), alternate);
+        });
+        setLink(
+            "alternate",
+            `${window.location.origin}${pathname}`,
+            "x-default"
+        );
+
+        // Social and LLM crawlers read these rather than the title/description
+        // pair, so they have to track the route too.
+        setMeta("property", "og:title", document.title);
+        setMeta("property", "og:description", t(`${route.key}.description`));
+        setMeta("property", "og:url", canonicalUrl(pathname, language));
+        setMeta("property", "og:locale", OG_LOCALE[language]);
+        setMeta("name", "twitter:title", document.title);
+        setMeta("name", "twitter:description", t(`${route.key}.description`));
+    }, [pathname, i18n.language, t]);
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -9,7 +9,14 @@ i18n.use(HttpApi)
     .use(LanguageDetector)
     .use(initReactI18next)
     .init({
-        ns: ["DataProtection", "Footer", "Header", "HomePage", "QueryPage"],
+        ns: [
+            "DataProtection",
+            "Footer",
+            "Header",
+            "HomePage",
+            "QueryPage",
+            "Seo",
+        ],
         debug: false,
         detection: {
             order: ["localStorage"],

--- a/src/locales/de/Seo.json
+++ b/src/locales/de/Seo.json
@@ -1,0 +1,42 @@
+{
+  "home": {
+    "title": "ZooNotify — Zoonosen-Surveillancedaten des BfR",
+    "description": "Web-basierte Abfrage von Surveillancedaten gemäß RL 99/2003/EU (Zoonosenrichtlinie): Erregernachweise in der Lebensmittelkette, erhoben vom BfR."
+  },
+  "prevalence": {
+    "title": "Prävalenz",
+    "description": "Prävalenz von Zoonoseerregern in der Lebensmittelkette in Deutschland — interaktive Auswertung nach Erreger, Matrix und Probenahmestufe."
+  },
+  "antibioticResistance": {
+    "title": "Antibiotikaresistenz",
+    "description": "Antibiotikaresistenzen bei Zoonoseerregern und kommensalen Bakterien in Deutschland — Trends, Einzelsubstanzen und Mehrfachresistenzen."
+  },
+  "microbialCounts": {
+    "title": "Keimzahlen",
+    "description": "Mikrobielle Keimzahlen entlang der Lebensmittelkette in Deutschland, erhoben im Rahmen des Zoonosen-Monitorings."
+  },
+  "antimicrobial": {
+    "title": "Antibiotikaeinsatz",
+    "description": "Daten zum Antibiotikaeinsatz bei lebensmittelliefernden Tieren in Deutschland, zusammengestellt vom Bundesinstitut für Risikobewertung."
+  },
+  "evaluations": {
+    "title": "Auswertungen",
+    "description": "Grafische Auswertungen und Zeitreihen zu Zoonoseerregern, Antibiotikaresistenzen und Keimzahlen aus dem deutschen Zoonosen-Monitoring."
+  },
+  "explanations": {
+    "title": "Erläuterungen",
+    "description": "Begriffe, Methoden und Datengrundlagen des Zoonosen-Monitorings: Erläuterungen zu Erregern, Matrizes, Probenahmestufen und Resistenzdaten."
+  },
+  "links": {
+    "title": "Externe Links",
+    "description": "Weiterführende Quellen zu Zoonosen, Antibiotikaresistenz und Lebensmittelsicherheit von BfR, EFSA, RKI und weiteren Institutionen."
+  },
+  "dataProtection": {
+    "title": "Datenschutzerklärung",
+    "description": "Datenschutzerklärung für ZooNotify, das Portal für Zoonosen-Surveillancedaten des Bundesinstituts für Risikobewertung (BfR)."
+  },
+  "notFound": {
+    "title": "Seite nicht gefunden",
+    "description": "Die aufgerufene Seite existiert nicht."
+  }
+}

--- a/src/locales/en/Seo.json
+++ b/src/locales/en/Seo.json
@@ -1,0 +1,42 @@
+{
+  "home": {
+    "title": "ZooNotify — Zoonotic Disease Surveillance Data from the BfR",
+    "description": "Web-based query tool for surveillance data collected under Directive 99/2003/EC (Zoonoses Directive): pathogen findings along the food chain, published by the BfR."
+  },
+  "prevalence": {
+    "title": "Prevalence",
+    "description": "Prevalence of zoonotic pathogens along the German food chain — explore the data interactively by pathogen, matrix and sampling stage."
+  },
+  "antibioticResistance": {
+    "title": "Antibiotic Resistance",
+    "description": "Antimicrobial resistance in zoonotic and commensal bacteria in Germany — trends, individual substances and multi-resistance patterns."
+  },
+  "microbialCounts": {
+    "title": "Microbial Counts",
+    "description": "Microbial counts along the German food chain, collected as part of the national zoonoses monitoring programme."
+  },
+  "antimicrobial": {
+    "title": "Antimicrobial Use",
+    "description": "Data on antimicrobial use in food-producing animals in Germany, compiled by the German Federal Institute for Risk Assessment (BfR)."
+  },
+  "evaluations": {
+    "title": "Evaluations",
+    "description": "Charts and time series covering zoonotic pathogens, antimicrobial resistance and microbial counts from the German zoonoses monitoring programme."
+  },
+  "explanations": {
+    "title": "Explanations",
+    "description": "Terminology, methods and data sources behind the zoonoses monitoring programme: pathogens, matrices, sampling stages and resistance data explained."
+  },
+  "links": {
+    "title": "External Links",
+    "description": "Further sources on zoonoses, antimicrobial resistance and food safety from the BfR, EFSA, RKI and other institutions."
+  },
+  "dataProtection": {
+    "title": "Privacy Policy",
+    "description": "Privacy policy for ZooNotify, the zoonotic disease surveillance data portal of the German Federal Institute for Risk Assessment (BfR)."
+  },
+  "notFound": {
+    "title": "Page not found",
+    "description": "The requested page does not exist."
+  }
+}


### PR DESCRIPTION
- useSeo resolves title, description, canonical, hreflang alternates, Open Graph/Twitter tags and the document lang from the active route and language, updating P0's static tags in place rather than appending duplicates.
- SEO_ROUTES maps every pageRoute entry to a key in a new Seo i18n namespace; copy lives in src/locales/{de,en}/Seo.json.
- Unknown paths get robots noindex so 404s are not advertised, and known routes reset it so a 404 visit cannot poison the next page.

Mounted once in BodyRouterComponent rather than in each of the nine page components: a route added later cannot ship without metadata, and there is a single place the rules live.

Canonical carries only ?lang=. The data pages push filter state into the query string, and folding that in would mint a fresh canonical for every filter combination a crawler happens to reach.

Tests drive the head through the real hook with a real i18next instance seeded from the real locale files - only the HTTP backend is swapped for in-memory resources. The route-parity test iterates pageRoute, so adding a route without adding its copy fails the suite.