### PR TITLE
feat(seo): unify the language URL parameter on ?lang=

### DIFF
--- a/src/app/antimicrobial/pages/antimicrobialUseCase.ts
+++ b/src/app/antimicrobial/pages/antimicrobialUseCase.ts
@@ -1,7 +1,6 @@
 import i18next from "i18next";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useHistory, useLocation } from "react-router-dom";
 import { callApiService } from "../../shared/infrastructure/api/callApi.service";
 import { AMU_PAGE } from "../../shared/infrastructure/router/routes";
 import { UseCase } from "../../shared/model/UseCases";
@@ -37,30 +36,12 @@ export const useAntimicrobialPageComponent: UseCase<
     const hardCodedTitle = t("AntimicrobialTitle") || "";
     const hardCodedDescription = t("AntimicrobialDescription") || "";
 
-    const location = useLocation();
-    const history = useHistory();
-
     const [title, setTitle] = useState<string>(hardCodedTitle);
     const [description, setDescription] =
         useState<string>(hardCodedDescription);
 
-    // sync URL → i18next
-    useEffect(() => {
-        const params = new URLSearchParams(location.search);
-        const localeParam = params.get("locale");
-        if (localeParam && localeParam !== i18next.language) {
-            i18next.changeLanguage(localeParam);
-        }
-    }, [location.search]);
-
-    // sync i18next → URL
-    useEffect(() => {
-        const params = new URLSearchParams(location.search);
-        if (params.get("locale") !== i18next.language) {
-            params.set("locale", i18next.language);
-            history.replace({ search: params.toString() });
-        }
-    }, [i18next.language, location.search, history]);
+    // Language <-> URL sync is useLanguageUrlSync's job, mounted once in
+    // Body-Router.component.tsx.
 
     // fetch + parse with async/await
     useEffect(() => {

--- a/src/app/evaluations/components/EvaluationDataContext.tsx
+++ b/src/app/evaluations/components/EvaluationDataContext.tsx
@@ -228,27 +228,9 @@ export const EvaluationDataProvider: React.FC<{ children: ReactNode }> = ({
     // guard against stale fetches overwriting fresh state
     const fetchIdRef = useRef(0);
 
-    // On first mount: align with ?lang=... if present; otherwise write current language to URL.
-    useEffect(() => {
-        const params = new URLSearchParams(window.location.search);
-        const urlLang = params.get("lang");
-
-        if (urlLang && urlLang !== i18n.language) {
-            i18n.changeLanguage(urlLang);
-        }
-        if (!urlLang) {
-            params.set("lang", i18n.language);
-            const newSearch = `?${params.toString()}`;
-            if (newSearch !== window.location.search) {
-                window.history.replaceState(
-                    {},
-                    "",
-                    `${window.location.pathname}${newSearch}`
-                );
-            }
-        }
-        // run once on mount
-    }, []);
+    // Aligning i18next with ?lang= is useLanguageUrlSync's job, mounted once in
+    // Body-Router.component.tsx, so it now happens for every route rather than
+    // only the ones that remembered to do it.
 
     // Fetch data whenever the app language changes.
     // IMPORTANT: Reset filters unless URL explicitly provides them (prevents “no results” after language switch).

--- a/src/app/explanation/pages/explanationUseCases.ts
+++ b/src/app/explanation/pages/explanationUseCases.ts
@@ -110,29 +110,10 @@ const useExplanationPageComponent: UseCase<
     const [deepLink, setDeepLink] = useState<string>("");
     const [activeAnchor, setActiveAnchor] = useState<string | null>(null);
 
-    // --- keep ?lang in sync with i18next ---
+    // Keeping ?lang in sync with i18next is useLanguageUrlSync's job, mounted
+    // once in Body-Router.component.tsx. This effect only builds the shareable
+    // deep link for the copy-link control.
     useEffect(() => {
-        const params = new URLSearchParams(location.search);
-        const queryLang = params.get("lang");
-        if (queryLang && queryLang !== i18next.language) {
-            i18next.changeLanguage(queryLang);
-        }
-    }, [location.search]);
-
-    useEffect(() => {
-        const params = new URLSearchParams(location.search);
-
-        // Ensure URL always has the current language
-        if (params.get("lang") !== i18next.language) {
-            params.set("lang", i18next.language);
-            history.replace({
-                pathname: location.pathname,
-                search: params.toString(),
-                hash: location.hash,
-            });
-        }
-
-        // Build deep link from current path + query + hash
         const currentUrl = window.location.origin + window.location.pathname;
         const finalParams = new URLSearchParams(location.search);
         if (finalParams.get("lang") !== i18next.language) {
@@ -140,13 +121,7 @@ const useExplanationPageComponent: UseCase<
         }
         const qs = finalParams.toString();
         setDeepLink(`${currentUrl}?${qs}${location.hash || ""}`);
-    }, [
-        i18next.language,
-        location.pathname,
-        location.search,
-        location.hash,
-        history,
-    ]);
+    }, [i18next.language, location.pathname, location.search, location.hash]);
 
     // --- read the hash whenever it changes and scroll into view ---
     useEffect(() => {

--- a/src/app/microbial_counts/pages/microbialCountsUseCase.ts
+++ b/src/app/microbial_counts/pages/microbialCountsUseCase.ts
@@ -2,7 +2,6 @@
 import i18next from "i18next";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useLocation, useHistory } from "react-router-dom";
 import { callApiService } from "../../shared/infrastructure/api/callApi.service";
 import { MICROBIAL_COUNTS } from "../../shared/infrastructure/router/routes";
 import { UseCase } from "../../shared/model/UseCases";
@@ -39,30 +38,12 @@ export const useMicrobialCountsPageComponent: UseCase<
     const hardCodedDescription =
         t("MicrobialCountsDescription") || "No content available yet.";
 
-    const location = useLocation();
-    const history = useHistory();
-
     const [title, setTitle] = useState<string>(hardCodedTitle);
     const [description, setDescription] =
         useState<string>(hardCodedDescription);
 
-    // URL -> i18next
-    useEffect(() => {
-        const params = new URLSearchParams(location.search);
-        const localeParam = params.get("locale");
-        if (localeParam && localeParam !== i18next.language) {
-            i18next.changeLanguage(localeParam);
-        }
-    }, [location.search]);
-
-    // i18next -> URL
-    useEffect(() => {
-        const params = new URLSearchParams(location.search);
-        if (params.get("locale") !== i18next.language) {
-            params.set("locale", i18next.language);
-            history.replace({ search: params.toString() });
-        }
-    }, [i18next.language, location.search, history]);
+    // Language <-> URL sync is useLanguageUrlSync's job, mounted once in
+    // Body-Router.component.tsx.
 
     // fetch content
     useEffect(() => {

--- a/src/app/pages/links/LinkPage-LinkList.component.tsx
+++ b/src/app/pages/links/LinkPage-LinkList.component.tsx
@@ -34,15 +34,8 @@ export function LinkPageLinkListComponent(): JSX.Element {
     const { t, i18n } = useTranslation(["ExternLinks"]);
     const [linkData, setLinkData] = useState<ExternalLink[]>([]);
 
-    // Update the browser URL to always include the current language as a query parameter.
-    useEffect(() => {
-        const params = new URLSearchParams(window.location.search);
-        if (params.get("lang") !== i18n.language) {
-            params.set("lang", i18n.language);
-            const newUrl = `${window.location.pathname}?${params.toString()}`;
-            window.history.replaceState({}, "", newUrl);
-        }
-    }, [i18n.language]);
+    // The ?lang= parameter is maintained by useLanguageUrlSync, mounted once in
+    // Body-Router.component.tsx.
 
     useEffect(() => {
         const apiEndpoint = `${EXTERNAL_LINKS}?locale=${i18n.language}`;

--- a/src/app/prevalence/components/PrevalenceDataContext.tsx
+++ b/src/app/prevalence/components/PrevalenceDataContext.tsx
@@ -254,21 +254,8 @@ export const PrevalenceDataProvider: React.FC<{ children: ReactNode }> = ({
     children,
 }) => {
     // -------------- Language Setup --------------
-    useEffect(() => {
-        const urlSearchParams = new URLSearchParams(window.location.search);
-        const langParam = urlSearchParams.get("lang");
-        if (langParam && langParam !== i18next.language) {
-            i18next.changeLanguage(langParam);
-        }
-        if (!langParam) {
-            urlSearchParams.set("lang", i18next.language);
-            window.history.replaceState(
-                null,
-                "",
-                `?${urlSearchParams.toString()}`
-            );
-        }
-    }, []);
+    // Handled by useLanguageUrlSync, mounted once in
+    // Body-Router.component.tsx.
 
     // -------------- State --------------
     const [selectedMicroorganisms, setSelectedMicroorganisms] = useState<

--- a/src/app/shared/infrastructure/router/Body-Router.component.tsx
+++ b/src/app/shared/infrastructure/router/Body-Router.component.tsx
@@ -14,14 +14,18 @@ import { MicrobialCountsPageComponent } from "../../../microbial_counts/pages/Mi
 
 import { pageRoute } from "./routes";
 import { useSeo } from "../../seo/useSeo";
+import { useLanguageUrlSync } from "../../seo/useLanguageUrlSync";
 
 function ErrorPage(): JSX.Element {
     return <ErrorPageComponent errorStatus={404} />;
 }
 
 export function BodyRouterComponent(): JSX.Element {
-    // Mounted here, inside the router but above the Switch, so it runs for every
-    // route -- including any added later without a matching wiring step.
+    // Mounted here, inside the router but above the Switch, so they run for
+    // every route -- including any added later without a matching wiring step.
+    // Keeping the language sync in one place is what stopped the per-page
+    // effects from writing two different parameter names at each other.
+    useLanguageUrlSync();
     useSeo();
 
     return (

--- a/src/app/shared/seo/__tests__/useLanguageUrlSync.test.tsx
+++ b/src/app/shared/seo/__tests__/useLanguageUrlSync.test.tsx
@@ -1,0 +1,134 @@
+import React, { ReactNode } from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+// eslint-disable-next-line import/named
+import i18next, { i18n as I18nInstance } from "i18next";
+import { I18nextProvider, initReactI18next } from "react-i18next";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { pageRoute } from "../../infrastructure/router/routes";
+import { useLanguageUrlSync } from "../useLanguageUrlSync";
+
+/**
+ * A real i18next instance and a real router -- nothing about the hook is
+ * mocked, so these tests drive the same path the browser does. The hook does no
+ * translating, so an empty resource set is enough.
+ */
+async function createI18n(language: string): Promise<I18nInstance> {
+    const instance = i18next.createInstance();
+    await instance.use(initReactI18next).init({
+        lng: language,
+        fallbackLng: "de",
+        resources: { de: {}, en: {} },
+        interpolation: { escapeValue: false },
+    });
+    return instance;
+}
+
+type Rendered = {
+    i18n: I18nInstance;
+    search: () => string;
+    hash: () => string;
+    pathname: () => string;
+};
+
+async function renderAt(path: string, language = "de"): Promise<Rendered> {
+    const instance = await createI18n(language);
+    const wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+        <I18nextProvider i18n={instance}>
+            <MemoryRouter initialEntries={[path]}>{children}</MemoryRouter>
+        </I18nextProvider>
+    );
+
+    const { result } = renderHook(
+        () => {
+            useLanguageUrlSync();
+            return useLocation();
+        },
+        { wrapper }
+    );
+
+    // The hook may change the language, which re-renders and then rewrites the
+    // URL; let both effects settle before asserting.
+    await act(async () => undefined);
+
+    return {
+        i18n: instance,
+        search: () => result.current.search,
+        hash: () => result.current.hash,
+        pathname: () => result.current.pathname,
+    };
+}
+
+describe("useLanguageUrlSync", () => {
+    it("adopts the language the URL asks for, so a shared link opens in its own language", async () => {
+        const { i18n } = await renderAt("/prevalence?lang=en", "de");
+
+        await waitFor(() => expect(i18n.language).toBe("en"));
+    });
+
+    it("still honours a legacy ?locale= link, so old bookmarks and citations keep working", async () => {
+        const { i18n } = await renderAt("/evaluations?locale=en", "de");
+
+        await waitFor(() => expect(i18n.language).toBe("en"));
+    });
+
+    it("rewrites a legacy ?locale= link to ?lang= so the two spellings stop competing", async () => {
+        const { search } = await renderAt("/evaluations?locale=en", "de");
+
+        await waitFor(() => {
+            expect(new URLSearchParams(search()).get("lang")).toBe("en");
+            expect(new URLSearchParams(search()).has("locale")).toBe(false);
+        });
+    });
+
+    it.each(Object.values(pageRoute))(
+        "writes the active language into %s, so every URL is shareable",
+        async (path) => {
+            const { search } = await renderAt(path, "de");
+
+            await waitFor(() =>
+                expect(new URLSearchParams(search()).get("lang")).toBe("de")
+            );
+        }
+    );
+
+    it("leaves filter state intact, so AMR deep links survive the rewrite", async () => {
+        const { search } = await renderAt(
+            "/antibiotic-resistance?microorganism=E.coli&view=trend&s=eJyrVgpKLU4tLsnMz1MoLknMK04tKlbSUUpKTM5OLVayUipKzUst"
+        );
+
+        await waitFor(() => {
+            const params = new URLSearchParams(search());
+            expect(params.get("microorganism")).toBe("E.coli");
+            expect(params.get("view")).toBe("trend");
+            expect(params.get("s")).toBe(
+                "eJyrVgpKLU4tLsnMz1MoLknMK04tKlbSUUpKTM5OLVayUipKzUst"
+            );
+            expect(params.get("lang")).toBe("de");
+        });
+    });
+
+    it("keeps the anchor, so explanation deep links still scroll to their term", async () => {
+        const { hash, pathname } = await renderAt(
+            "/explanations?locale=en#salmonella"
+        );
+
+        await waitFor(() => {
+            expect(hash()).toBe("#salmonella");
+            expect(pathname()).toBe("/explanations");
+        });
+    });
+
+    it("ignores an unsupported language rather than yanking the reader out of theirs", async () => {
+        const { i18n } = await renderAt("/prevalence?lang=fr", "en");
+
+        await waitFor(() => expect(i18n.language).toBe("en"));
+    });
+
+    it("corrects an unsupported language in the URL to the one actually in use", async () => {
+        const { search } = await renderAt("/prevalence?lang=fr", "en");
+
+        await waitFor(() =>
+            expect(new URLSearchParams(search()).get("lang")).toBe("en")
+        );
+    });
+});

--- a/src/app/shared/seo/seo.model.ts
+++ b/src/app/shared/seo/seo.model.ts
@@ -4,6 +4,20 @@ import { pageRoute } from "../infrastructure/router/routes";
 export const SEO_LANGUAGES = ["de", "en"] as const;
 export type SeoLanguage = (typeof SEO_LANGUAGES)[number];
 
+const baseLanguage = (value: string | undefined | null): string =>
+    (value || "").split("-")[0].toLowerCase();
+
+/**
+ * Whether we publish this language at all. Kept separate from
+ * `normalizeLanguage` because the two answer different questions: callers
+ * acting on a URL-supplied value need to know it is real BEFORE collapsing it,
+ * otherwise "?lang=fr" reads as a request for the fallback and silently drags
+ * an English reader into German.
+ */
+export function isSupportedLanguage(value: string | undefined | null): boolean {
+    return (SEO_LANGUAGES as readonly string[]).includes(baseLanguage(value));
+}
+
 /**
  * i18next hands back tags like "de-DE"; our URLs and the `lang` attribute only
  * ever carry the bare language. Anything unrecognised falls back to the same
@@ -12,10 +26,8 @@ export type SeoLanguage = (typeof SEO_LANGUAGES)[number];
 export function normalizeLanguage(
     value: string | undefined | null
 ): SeoLanguage {
-    const base = (value || "").split("-")[0].toLowerCase();
-    return (SEO_LANGUAGES as readonly string[]).includes(base)
-        ? (base as SeoLanguage)
-        : "de";
+    const base = baseLanguage(value);
+    return isSupportedLanguage(base) ? (base as SeoLanguage) : "de";
 }
 
 export type SeoRoute = {

--- a/src/app/shared/seo/useLanguageUrlSync.ts
+++ b/src/app/shared/seo/useLanguageUrlSync.ts
@@ -1,0 +1,61 @@
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { useHistory, useLocation } from "react-router-dom";
+import { isSupportedLanguage, normalizeLanguage } from "./seo.model";
+
+/** The query parameter that carries the active language. */
+export const LANG_PARAM = "lang";
+
+/** Pre-unification parameter name, still read so old links keep working. */
+export const LEGACY_LANG_PARAM = "locale";
+
+/**
+ * Single source of truth for the language <-> URL relationship.
+ *
+ * Mounted once inside the router; see Body-Router.component.tsx.
+ */
+export function useLanguageUrlSync(): void {
+    const { i18n } = useTranslation();
+    const location = useLocation();
+    const history = useHistory();
+
+    useEffect(() => {
+        const params = new URLSearchParams(location.search);
+        const requested =
+            params.get(LANG_PARAM) ?? params.get(LEGACY_LANG_PARAM);
+        const active = normalizeLanguage(i18n.language);
+
+        // URL -> i18next. Only a language we actually publish is honoured; an
+        // unsupported value is left to the write-back below, which corrects the
+        // URL instead of moving the reader.
+        if (requested && isSupportedLanguage(requested)) {
+            const normalized = normalizeLanguage(requested);
+            if (normalized !== active) {
+                i18n.changeLanguage(normalized);
+                return;
+            }
+        }
+
+        // i18next -> URL, collapsing the legacy parameter onto the canonical one.
+        if (
+            params.get(LANG_PARAM) === active &&
+            !params.has(LEGACY_LANG_PARAM)
+        ) {
+            return;
+        }
+        params.delete(LEGACY_LANG_PARAM);
+        params.set(LANG_PARAM, active);
+        history.replace({
+            pathname: location.pathname,
+            search: params.toString(),
+            hash: location.hash,
+        });
+    }, [
+        location.search,
+        location.pathname,
+        location.hash,
+        i18n,
+        i18n.language,
+        history,
+    ]);
+}

--- a/src/app/welcome/pages/welcomeUseCase.ts
+++ b/src/app/welcome/pages/welcomeUseCase.ts
@@ -3,7 +3,6 @@ import { WELCOME } from "./../../shared/infrastructure/router/routes";
 import i18next, { TFunction } from "i18next";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useLocation, useHistory } from "react-router-dom";
 import { callApiService } from "../../shared/infrastructure/api/callApi.service";
 import { UseCase } from "../../shared/model/UseCases";
 
@@ -54,9 +53,6 @@ const useWelcomePageComponent: UseCase<
         [i18n.language]
     );
 
-    const location = useLocation();
-    const history = useHistory();
-
     // Start empty to avoid flashing the hard-coded text.
     const [subtitle, setSubtitle] = useState<string>("");
     const [content, setContent] = useState<string>("");
@@ -64,25 +60,10 @@ const useWelcomePageComponent: UseCase<
     // Keep a flag to know if we've tried the CMS already.
     const fetchedRef = useRef(false);
 
-    // Effect 1: if URL has ?locale=xyz and it's different, switch i18n.
-    useEffect(() => {
-        const params = new URLSearchParams(location.search);
-        const localeParam = params.get("locale");
-        if (localeParam && localeParam !== i18next.language) {
-            i18next.changeLanguage(localeParam);
-        }
-    }, [location.search]);
+    // Language <-> URL sync is useLanguageUrlSync's job, mounted once in
+    // Body-Router.component.tsx.
 
-    // Effect 2: reflect current i18n language back to the URL.
-    useEffect(() => {
-        const params = new URLSearchParams(location.search);
-        if (params.get("locale") !== i18next.language) {
-            params.set("locale", i18next.language);
-            history.replace({ search: params.toString() });
-        }
-    }, [i18next.language, location.search, history]);
-
-    // Effect 3: fetch from CMS; if empty or error, fall back to hard-coded.
+    // Effect: fetch from CMS; if empty or error, fall back to hard-coded.
     useEffect(() => {
         const controller = new AbortController();
         const signal = controller.signal;

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -19,7 +19,15 @@ i18n.use(HttpApi)
         ],
         debug: false,
         detection: {
-            order: ["localStorage"],
+            // querystring first: someone arriving from a search result or a
+            // shared link must get that link's language on the FIRST render.
+            // With localStorage alone the app booted in the stored language and
+            // only corrected itself once a page effect ran, so a crawler could
+            // capture the wrong language entirely. Only `lang` is resolved here
+            // (the detector takes a single parameter name); legacy `?locale=`
+            // links are picked up a moment later by useLanguageUrlSync.
+            order: ["querystring", "localStorage"],
+            lookupQuerystring: "lang",
             lookupLocalStorage: "i18nextLng",
         },
         fallbackLng: "de",


### PR DESCRIPTION
The active language was written to the URL by seven independent per-page effects that disagreed: welcome, microbial counts and antimicrobial wrote ?locale=, while explanations, links, evaluations and prevalence wrote ?lang=. Data Protection wrote nothing, so its URL rendered in whatever language localStorage happened to hold. Search engines saw ?lang=de and ?locale=de as two different URLs serving identical content, and P1's canonical tags pointed at ?lang= URLs the app itself did not always produce.

This is P2 of docs/seo-audit.md:

- useLanguageUrlSync replaces all seven effects. It reads ?lang=, falls back to ?locale= so existing bookmarks and citations keep working, then rewrites to ?lang= and drops the legacy parameter. Mounted once in Body-Router.component.tsx, so every route is covered.
- i18n detection now tries the querystring before localStorage, so a visitor arriving from a search result gets that link's language on the first render rather than after a visible flip.

An unsupported value such as ?lang=fr no longer drags the reader into the fallback language: isSupportedLanguage is now separate from normalizeLanguage, because collapsing an unknown value before checking it made "?lang=fr" read as a request for German and silently moved English readers. The URL is corrected to the language actually in use instead.

Filter state and anchors survive the rewrite - the AMR compressed s= blob, microorganism/view, and explanation term hashes are all preserved.

The AMR URL builders and the header language switcher keep their own ?lang= writes; they compose whole URLs rather than syncing, and already use the canonical spelling.