### PR TITLE
feat(seo): describe pages with schema.org JSON-LD

### DIFF
--- a/src/app/shared/seo/__tests__/useSeo.test.tsx
+++ b/src/app/shared/seo/__tests__/useSeo.test.tsx
@@ -64,6 +64,19 @@ const metaContent = (selector: string): string | null =>
 const linkHref = (selector: string): string | null =>
     document.head.querySelector(selector)?.getAttribute("href") ?? null;
 
+const jsonLdScripts = (): HTMLScriptElement[] =>
+    Array.from(
+        document.head.querySelectorAll<HTMLScriptElement>(
+            'script[type="application/ld+json"]'
+        )
+    );
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const jsonLd = (): any => {
+    const [script] = jsonLdScripts();
+    return script ? JSON.parse(script.textContent ?? "null") : null;
+};
+
 beforeEach(() => {
     seedStaticHead();
 });
@@ -205,5 +218,88 @@ describe("useSeo", () => {
         expect(metaContent('meta[property="og:url"]')).toBe(
             "http://localhost/prevalence?lang=en"
         );
+    });
+});
+
+describe("useSeo structured data", () => {
+    it("describes a data route as a schema.org Dataset, so it can surface in Dataset Search", async () => {
+        await renderAt("/prevalence");
+
+        expect(jsonLd()["@type"]).toBe("Dataset");
+    });
+
+    it.each(["/prevalence", "/antibiotic-resistance", "/microbial-counts"])(
+        "credits the BfR as the source of the dataset on %s",
+        async (path) => {
+            await renderAt(path, "en");
+            const data = jsonLd();
+
+            expect(data["@type"]).toBe("Dataset");
+            // A raw i18n key would mean the copy is missing, not that it resolved.
+            expect(data.name).not.toContain("datasetName");
+            expect(data.name).toBeTruthy();
+            expect(data.creator).toMatchObject({
+                "@type": "GovernmentOrganization",
+                url: "https://www.bfr.bund.de/",
+            });
+            expect(data.url).toBe(`http://localhost${path}?lang=en`);
+            expect(data.inLanguage).toBe("en");
+        }
+    );
+
+    it("does not claim licence terms or a reporting period it cannot verify", async () => {
+        await renderAt("/prevalence");
+        const data = jsonLd();
+
+        expect(data.license).toBeUndefined();
+        expect(data.temporalCoverage).toBeUndefined();
+    });
+
+    it("attributes the site itself to the BfR on the home route", async () => {
+        await renderAt("/");
+        const data = jsonLd();
+
+        expect(data["@type"]).toBe("WebSite");
+        expect(data.publisher).toMatchObject({
+            "@type": "GovernmentOrganization",
+            url: "https://www.bfr.bund.de/",
+        });
+        expect(data.inLanguage).toEqual(expect.arrayContaining(["de", "en"]));
+    });
+
+    it("still describes prose routes, so they are not structurally anonymous", async () => {
+        await renderAt("/explanations");
+
+        expect(jsonLd()["@type"]).toBe("WebPage");
+    });
+
+    it("emits exactly one block after navigating, so crawlers do not see a stale page described alongside the current one", async () => {
+        await renderAt("/prevalence");
+        await renderAt("/explanations");
+
+        expect(jsonLdScripts()).toHaveLength(1);
+        expect(jsonLd()["@type"]).toBe("WebPage");
+    });
+
+    it("re-describes the page when the language changes", async () => {
+        const { i18n } = await renderAt("/prevalence", "de");
+        expect(jsonLd().inLanguage).toBe("de");
+        const germanName = jsonLd().name;
+
+        await act(async () => {
+            await i18n.changeLanguage("en");
+        });
+
+        expect(jsonLd().inLanguage).toBe("en");
+        expect(jsonLd().name).not.toBe(germanName);
+    });
+
+    it("emits parseable JSON carrying the schema.org context", async () => {
+        await renderAt("/microbial-counts");
+        const [script] = jsonLdScripts();
+
+        expect(script.getAttribute("type")).toBe("application/ld+json");
+        expect(() => JSON.parse(script.textContent ?? "")).not.toThrow();
+        expect(jsonLd()["@context"]).toBe("https://schema.org");
     });
 });

--- a/src/app/shared/seo/seo.model.ts
+++ b/src/app/shared/seo/seo.model.ts
@@ -30,11 +30,22 @@ export function normalizeLanguage(
     return isSupportedLanguage(base) ? (base as SeoLanguage) : "de";
 }
 
+/**
+ * Marks a route as publishing an actual dataset rather than prose. Only these
+ * emit schema.org Dataset markup, which is what makes them eligible for Google
+ * Dataset Search.
+ */
+export type SeoDataset = {
+    /** Key in the Seo i18n namespace holding the dataset's formal name. */
+    readonly nameKey: string;
+};
+
 export type SeoRoute = {
     /** Route path as declared in `pageRoute`. */
     readonly path: string;
     /** Key in the Seo i18n namespace: `<key>.title` and `<key>.description`. */
     readonly key: string;
+    readonly dataset?: SeoDataset;
 };
 
 /**
@@ -47,13 +58,22 @@ export const SEO_ROUTES: readonly SeoRoute[] = [
     { path: pageRoute.infoPagePath, key: "explanations" },
     { path: pageRoute.evaluationsPagePath, key: "evaluations" },
     { path: pageRoute.dpdPagePath, key: "dataProtection" },
-    { path: pageRoute.prevalencePagePath, key: "prevalence" },
+    {
+        path: pageRoute.prevalencePagePath,
+        key: "prevalence",
+        dataset: { nameKey: "prevalence.datasetName" },
+    },
     { path: pageRoute.antimicrobialPagePath, key: "antimicrobial" },
     {
         path: pageRoute.antibioticResistancePagePath,
         key: "antibioticResistance",
+        dataset: { nameKey: "antibioticResistance.datasetName" },
     },
-    { path: pageRoute.microbialCountsPagePath, key: "microbialCounts" },
+    {
+        path: pageRoute.microbialCountsPagePath,
+        key: "microbialCounts",
+        dataset: { nameKey: "microbialCounts.datasetName" },
+    },
 ];
 
 /**

--- a/src/app/shared/seo/useSeo.ts
+++ b/src/app/shared/seo/useSeo.ts
@@ -6,6 +6,7 @@ import {
     normalizeLanguage,
     SEO_LANGUAGES,
     SeoLanguage,
+    SeoRoute,
 } from "./seo.model";
 
 /**
@@ -16,6 +17,14 @@ import {
 const MANAGED_ATTR = "data-seo-managed";
 
 const OG_LOCALE: Record<SeoLanguage, string> = { de: "de_DE", en: "en_GB" };
+
+/** The publishing institute, reused across every structured-data node. */
+const BFR = {
+    "@type": "GovernmentOrganization",
+    name: "Bundesinstitut für Risikobewertung",
+    alternateName: "German Federal Institute for Risk Assessment",
+    url: "https://www.bfr.bund.de/",
+} as const;
 
 function upsert<E extends HTMLElement>(selector: string, create: () => E): E {
     const existing = document.head.querySelector<E>(selector);
@@ -60,6 +69,78 @@ function setLink(rel: string, href: string, hreflang?: string): void {
  */
 function canonicalUrl(pathname: string, language: SeoLanguage): string {
     return `${window.location.origin}${pathname}?lang=${language}`;
+}
+
+/**
+ * One node per page, picked by what the page actually is: the site itself on
+ * the home route, a Dataset where the page publishes data, and a plain WebPage
+ * for prose. Emitting Dataset everywhere would misdescribe the glossary and the
+ * privacy policy as data products.
+ */
+function buildJsonLd(
+    route: SeoRoute,
+    language: SeoLanguage,
+    pathname: string,
+    title: string,
+    description: string,
+    datasetName: string | null
+): Record<string, unknown> {
+    const origin = window.location.origin;
+
+    if (route.key === "home") {
+        return {
+            "@context": "https://schema.org",
+            "@type": "WebSite",
+            name: "ZooNotify",
+            description,
+            url: `${origin}/`,
+            inLanguage: [...SEO_LANGUAGES],
+            publisher: BFR,
+        };
+    }
+
+    if (route.dataset && datasetName) {
+        return {
+            "@context": "https://schema.org",
+            "@type": "Dataset",
+            name: datasetName,
+            description,
+            url: canonicalUrl(pathname, language),
+            inLanguage: language,
+            isAccessibleForFree: true,
+            creator: BFR,
+            publisher: BFR,
+            spatialCoverage: { "@type": "Place", name: "Deutschland" },
+            // `license` and `temporalCoverage` are deliberately absent. Both are
+            // factual claims about BfR's published data that this codebase
+            // cannot derive, and wrong structured data is worse than incomplete
+            // structured data. Add them once BfR confirms the licence terms and
+            // the earliest reporting year.
+        };
+    }
+
+    return {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        name: title,
+        description,
+        url: canonicalUrl(pathname, language),
+        inLanguage: language,
+        isPartOf: { "@type": "WebSite", name: "ZooNotify", url: `${origin}/` },
+        publisher: BFR,
+    };
+}
+
+const JSON_LD_ID = "seo-json-ld";
+
+function setJsonLd(payload: Record<string, unknown>): void {
+    const script = upsert<HTMLScriptElement>(`script#${JSON_LD_ID}`, () => {
+        const element = document.createElement("script");
+        element.id = JSON_LD_ID;
+        element.type = "application/ld+json";
+        return element;
+    });
+    script.textContent = JSON.stringify(payload);
 }
 
 /**
@@ -110,5 +191,16 @@ export function useSeo(): void {
         setMeta("property", "og:locale", OG_LOCALE[language]);
         setMeta("name", "twitter:title", document.title);
         setMeta("name", "twitter:description", t(`${route.key}.description`));
+
+        setJsonLd(
+            buildJsonLd(
+                route,
+                language,
+                pathname,
+                document.title,
+                t(`${route.key}.description`),
+                route.dataset ? t(route.dataset.nameKey) : null
+            )
+        );
     }, [pathname, i18n.language, t]);
 }

--- a/src/locales/de/Seo.json
+++ b/src/locales/de/Seo.json
@@ -5,15 +5,18 @@
   },
   "prevalence": {
     "title": "Prävalenz",
-    "description": "Prävalenz von Zoonoseerregern in der Lebensmittelkette in Deutschland — interaktive Auswertung nach Erreger, Matrix und Probenahmestufe."
+    "description": "Prävalenz von Zoonoseerregern in der Lebensmittelkette in Deutschland — interaktive Auswertung nach Erreger, Matrix und Probenahmestufe.",
+    "datasetName": "Prävalenz von Zoonoseerregern in der Lebensmittelkette (Deutschland)"
   },
   "antibioticResistance": {
     "title": "Antibiotikaresistenz",
-    "description": "Antibiotikaresistenzen bei Zoonoseerregern und kommensalen Bakterien in Deutschland — Trends, Einzelsubstanzen und Mehrfachresistenzen."
+    "description": "Antibiotikaresistenzen bei Zoonoseerregern und kommensalen Bakterien in Deutschland — Trends, Einzelsubstanzen und Mehrfachresistenzen.",
+    "datasetName": "Antibiotikaresistenzen bei Zoonoseerregern und kommensalen Bakterien (Deutschland)"
   },
   "microbialCounts": {
     "title": "Keimzahlen",
-    "description": "Mikrobielle Keimzahlen entlang der Lebensmittelkette in Deutschland, erhoben im Rahmen des Zoonosen-Monitorings."
+    "description": "Mikrobielle Keimzahlen entlang der Lebensmittelkette in Deutschland, erhoben im Rahmen des Zoonosen-Monitorings.",
+    "datasetName": "Mikrobielle Keimzahlen in der Lebensmittelkette (Deutschland)"
   },
   "antimicrobial": {
     "title": "Antibiotikaeinsatz",

--- a/src/locales/en/Seo.json
+++ b/src/locales/en/Seo.json
@@ -5,15 +5,18 @@
   },
   "prevalence": {
     "title": "Prevalence",
-    "description": "Prevalence of zoonotic pathogens along the German food chain — explore the data interactively by pathogen, matrix and sampling stage."
+    "description": "Prevalence of zoonotic pathogens along the German food chain — explore the data interactively by pathogen, matrix and sampling stage.",
+    "datasetName": "Prevalence of zoonotic pathogens along the food chain (Germany)"
   },
   "antibioticResistance": {
     "title": "Antibiotic Resistance",
-    "description": "Antimicrobial resistance in zoonotic and commensal bacteria in Germany — trends, individual substances and multi-resistance patterns."
+    "description": "Antimicrobial resistance in zoonotic and commensal bacteria in Germany — trends, individual substances and multi-resistance patterns.",
+    "datasetName": "Antimicrobial resistance in zoonotic and commensal bacteria (Germany)"
   },
   "microbialCounts": {
     "title": "Microbial Counts",
-    "description": "Microbial counts along the German food chain, collected as part of the national zoonoses monitoring programme."
+    "description": "Microbial counts along the German food chain, collected as part of the national zoonoses monitoring programme.",
+    "datasetName": "Microbial counts along the food chain (Germany)"
   },
   "antimicrobial": {
     "title": "Antimicrobial Use",


### PR DESCRIPTION
The site carried no structured data, so search engines had to infer what each page was from prose alone. For a federal surveillance platform that mostly costs it eligibility for Google Dataset Search, which is a channel this audience actually uses.

- home -> WebSite published by the BfR as a GovernmentOrganization
- prevalence, antibiotic resistance, microbial counts -> Dataset, crediting the BfR as creator and publisher, with the route's canonical URL, active language, spatial coverage and free-access flag
- everything else -> WebPage that is part of the WebSite

Prose routes deliberately do not emit Dataset: marking the glossary or the privacy policy as a data product would misdescribe them.

`license` and `temporalCoverage` are deliberately omitted. Both are factual claims about BfR's published data that this codebase cannot derive, and a wrong licence claim on a federal institute's data is worse than an absent one. A test asserts they stay absent so neither gets guessed at later; add them once BfR confirms the terms and the earliest reporting year.