### PR TITLE
feat(footer): show the deployed commit hash on QA and local dev

### DIFF
--- a/.github/workflows/cd-qa.yml
+++ b/.github/workflows/cd-qa.yml
@@ -22,12 +22,16 @@ jobs:
           cache: 'npm'
       - run: npm ci
 
-      - name: Set build date
+      - name: Set build date and commit hash
         id: meta
-        run: echo "builddate=$(date +'%Y-%m-%dT%H:%M:%S%z')" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "builddate=$(date +'%Y-%m-%dT%H:%M:%S%z')" >> "$GITHUB_OUTPUT"
+          echo "commithash=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
+      # QA builds label themselves with the deployed commit instead of the
+      # package version (the footer tooltip reads `client commit@<hash>`).
       - name: Build
-        run: npm run build:qa -- --env=lastChange=${{ steps.meta.outputs.builddate }}
+        run: npm run build:qa -- --env=lastChange=${{ steps.meta.outputs.builddate }} --env=commitHash=${{ steps.meta.outputs.commithash }}
       # cross-env scopes NODE_ENV to the webpack process above, so cp:all needs
       # to be told separately, or the sitemap is built for the wrong host.
       - name: Copy static and crawler artifacts

--- a/.github/workflows/deploy-on-qa.yml
+++ b/.github/workflows/deploy-on-qa.yml
@@ -16,12 +16,16 @@ jobs:
           cache: 'npm'
       - run: npm ci
 
-      - name: Set build date
+      - name: Set build date and commit hash
         id: meta
-        run: echo "builddate=$(date +'%Y-%m-%dT%H:%M:%S%z')" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "builddate=$(date +'%Y-%m-%dT%H:%M:%S%z')" >> "$GITHUB_OUTPUT"
+          echo "commithash=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
+      # QA builds label themselves with the deployed commit instead of the
+      # package version (the footer tooltip reads `client commit@<hash>`).
       - name: Build
-        run: npm run build:qa -- --env=lastChange=${{ steps.meta.outputs.builddate }}
+        run: npm run build:qa -- --env=lastChange=${{ steps.meta.outputs.builddate }} --env=commitHash=${{ steps.meta.outputs.commithash }}
       # cross-env scopes NODE_ENV to the webpack process above, so cp:all needs
       # to be told separately, or the sitemap is built for the wrong host.
       - name: Copy static and crawler artifacts

--- a/src/app/shared/components/footer/LastUpdate.component.tsx
+++ b/src/app/shared/components/footer/LastUpdate.component.tsx
@@ -6,9 +6,18 @@ import { LastUpdateDateComponent } from "./LastUpdate-Date.component";
 import { LastUpdateVersionComponent } from "./LastUpdate-Version.component";
 
 export function LastUpdateComponent(): JSX.Element {
-    const { version } = environment;
+    const { version, commitHash } = environment;
     const theme = useTheme();
     const cmsVersion = window.sessionStorage.getItem("cms-version");
+    // On QA both sides report the short hash of the deployed commit; elsewhere
+    // they report their package version.
+    const cmsCommit = window.sessionStorage.getItem("cms-commit");
+    const serverText = cmsCommit
+        ? `server commit@${cmsCommit}`
+        : `server version@${cmsVersion}`;
+    const clientText = commitHash
+        ? `client commit@${commitHash}`
+        : `client version@${version}`;
     return (
         <Tooltip
             sx={{
@@ -23,12 +32,8 @@ export function LastUpdateComponent(): JSX.Element {
             title={
                 <>
                     <List dense>
-                        <LastUpdateVersionComponent
-                            text={`server version@${cmsVersion}`}
-                        />
-                        <LastUpdateVersionComponent
-                            text={`client version@${version}`}
-                        />
+                        <LastUpdateVersionComponent text={serverText} />
+                        <LastUpdateVersionComponent text={clientText} />
                     </List>
                 </>
             }

--- a/src/app/shared/infrastructure/api/callApi.service.ts
+++ b/src/app/shared/infrastructure/api/callApi.service.ts
@@ -18,6 +18,9 @@ export async function callApiService<T extends {}>(
     const apiResponse: Response = await fetch(apiUrl, options);
     const cmsVersion = apiResponse.headers.get("cms-version");
     window.sessionStorage.setItem("cms-version", cmsVersion ? cmsVersion : "");
+    // Only sent by QA deployments of the CMS.
+    const cmsCommit = apiResponse.headers.get("cms-commit");
+    window.sessionStorage.setItem("cms-commit", cmsCommit ? cmsCommit : "");
     const { status } = apiResponse;
 
     if (status === 200) {

--- a/src/environment.tsx
+++ b/src/environment.tsx
@@ -1,7 +1,10 @@
 declare const webappVersion: string;
+declare const commitHash: string;
 declare const lastChange: string;
 export const environment = {
     appName: "ZooNotify",
     version: webappVersion,
+    // Short git hash of the deployed commit; only set on QA builds.
+    commitHash: commitHash,
     lastChange: lastChange,
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,9 +3,35 @@ const backendURL = "http://localhost:3000";
 const contentBase = path.resolve(__dirname, "public");
 const Dotenv = require("dotenv-webpack");
 const webpack = require("webpack");
+const { execSync } = require("child_process");
 
 // Import package.json to access the version
 const packageJson = require("./package.json"); // Make sure the path to package.json is correct
+
+/**
+ * Short hash of the commit being built. QA passes it in explicitly
+ * (--env=commitHash=...); local dev reads it from the working copy. Production
+ * deliberately gets nothing so released builds report the package version.
+ * Returns "" when git is unavailable or this is not a checkout.
+ */
+function resolveCommitHash(env) {
+    if (env.commitHash) {
+        return String(env.commitHash);
+    }
+    if (process.env.NODE_ENV === "production") {
+        return "";
+    }
+    try {
+        return execSync("git rev-parse --short HEAD", {
+            cwd: __dirname,
+            stdio: ["ignore", "pipe", "ignore"],
+        })
+            .toString()
+            .trim();
+    } catch {
+        return "";
+    }
+}
 
 module.exports = (env, argv) => {
     return {
@@ -65,6 +91,7 @@ module.exports = (env, argv) => {
             }),
             new webpack.DefinePlugin({
                 webappVersion: JSON.stringify(packageJson.version),
+                commitHash: JSON.stringify(resolveCommitHash(env)),
                 lastChange: env.lastChange
                     ? JSON.stringify(env.lastChange)
                     : JSON.stringify(new Date().toISOString()),


### PR DESCRIPTION
The footer tooltip reported the package version for both client and server, which does not identify what is actually running on QA, where every push to develop deploys the same version.

Resolve a short commit hash in three tiers: an explicit build input (--env=commitHash, set by the QA workflows), then the local working copy, then nothing. The local lookup is skipped when NODE_ENV is production, so released builds keep reporting the package version.

The tooltip prefers the hash when present and labels it commit@ rather than version@. The server line reads the new cms-commit response header.