### PR TITLE
fix(antibiotic): remove double scrollbar on trend and substance views

### DIFF
--- a/src/app/antibiotic_resistance/pages/SubstanceDetail.tsx
+++ b/src/app/antibiotic_resistance/pages/SubstanceDetail.tsx
@@ -1423,7 +1423,18 @@ export const SubstanceDetail: React.FC<{
             <Box
                 display="flex"
                 flexDirection="row"
-                sx={{ width: "100%", height: "calc(100vh - 75px)" }}
+                sx={{
+                    // Fill the scroll area PageLayoutComponent's <main> hands
+                    // down rather than guessing the header height with a 100vh
+                    // offset. A row taller than <main> makes <main> scroll on
+                    // top of the results pane's own scrollbar -- that is the
+                    // double scrollbar. Clip here so each pane scrolls itself.
+                    width: "100%",
+                    height: "100%",
+                    maxHeight: "100%",
+                    minHeight: 0,
+                    overflow: "hidden",
+                }}
             >
                 {/* SIDEBAR */}
                 <SidebarComponent
@@ -1439,7 +1450,12 @@ export const SubstanceDetail: React.FC<{
                             p: 3,
                             width: "380px",
                             maxWidth: "95%",
-                            height: "calc(100vh - 150px)",
+                            // Fill the sidebar panel handed down by
+                            // SidebarComponent so this pane owns its scrollbar
+                            // and the Search/Reset buttons stay reachable.
+                            height: "100%",
+                            maxHeight: "100%",
+                            boxSizing: "border-box",
                         }}
                     >
                         {loading && (
@@ -1536,7 +1552,11 @@ export const SubstanceDetail: React.FC<{
                     px={4}
                     py={3}
                     sx={{
+                        // Shrink inside the clipped row so overflow:auto
+                        // scrolls this pane instead of stretching the row.
                         overflow: "auto",
+                        minHeight: 0,
+                        boxSizing: "border-box",
                         boxShadow: "15px 0 15px -15px rgba(0,0,0,0.15) inset",
                         backgroundColor: "#fff",
                         marginLeft: "20px",

--- a/src/app/antibiotic_resistance/pages/TrendDetails.tsx
+++ b/src/app/antibiotic_resistance/pages/TrendDetails.tsx
@@ -935,7 +935,18 @@ export const TrendDetails: React.FC<{
             <Box
                 display="flex"
                 flexDirection="row"
-                sx={{ width: "100%", height: "calc(100vh - 75px)" }}
+                sx={{
+                    // Fill the scroll area PageLayoutComponent's <main> hands
+                    // down rather than guessing the header height with a 100vh
+                    // offset. A row taller than <main> makes <main> scroll on
+                    // top of the results pane's own scrollbar -- that is the
+                    // double scrollbar. Clip here so each pane scrolls itself.
+                    width: "100%",
+                    height: "100%",
+                    maxHeight: "100%",
+                    minHeight: 0,
+                    overflow: "hidden",
+                }}
             >
                 {/* SIDEBAR */}
                 <SidebarComponent
@@ -951,7 +962,12 @@ export const TrendDetails: React.FC<{
                             p: 3,
                             width: "380px",
                             maxWidth: "95%",
-                            height: "calc(100vh - 150px)",
+                            // Fill the sidebar panel handed down by
+                            // SidebarComponent so this pane owns its scrollbar
+                            // and the Search/Reset buttons stay reachable.
+                            height: "100%",
+                            maxHeight: "100%",
+                            boxSizing: "border-box",
                         }}
                     >
                         {loading && (
@@ -1038,7 +1054,11 @@ export const TrendDetails: React.FC<{
                     px={4}
                     py={3}
                     sx={{
+                        // Shrink inside the clipped row so overflow:auto
+                        // scrolls this pane instead of stretching the row.
                         overflow: "auto",
+                        minHeight: 0,
+                        boxSizing: "border-box",
                         boxShadow: "15px 0 15px -15px rgba(0,0,0,0.15) inset",
                         backgroundColor: "#fff",
                         marginLeft: "20px",


### PR DESCRIPTION
The trend and substance detail views sized their layout row with height: calc(100vh - 75px) and their sidebar filter pane with calc(100vh - 150px) -- the hardcoded viewport-height guessing that the flex app-shell (3fde3e4) replaced everywhere else. Those offsets predate the app-shell and ignore the footer, so the row came out taller than PageLayoutComponent's <main>: 825px inside an 823px main at 1440x900. With overflow visible, <main> scrolled on top of the results pane's own scrollbar, putting two scrollbars side by side on the right edge. The mismatch widens on shorter viewports (20px at 660px tall).

Apply the pattern prevalence already uses (MainWithSideLayout / PrevalenceSideContent):
- the layout row fills main (height/maxHeight 100%, minHeight 0) and clips, so a tall pane scrolls inside itself instead of stretching main
- the sidebar filter pane fills the panel handed down by SidebarComponent rather than the viewport
- the results pane gets minHeight 0 and border-box so overflow:auto scrolls the pane instead of growing the row

Verified in the browser at 1440x900 and 1280x660 on both views: main stays at 823/823 and each pane scrolls on its own. The AMR landing view keeps its single intended main scrollbar (.abx-page min-height: 120vh).