### PR TITLE
Fix NaN year filter injected by MUI Select's "Select All" row

### DIFF
--- a/src/app/prevalence/components/PrevalenceDataContext.tsx
+++ b/src/app/prevalence/components/PrevalenceDataContext.tsx
@@ -510,9 +510,11 @@ export const PrevalenceDataProvider: React.FC<{ children: ReactNode }> = ({
                 field: string,
                 docIds: string[]
             ): void => {
-                if (docIds.length > 0) {
+                // Drop empties: a junk value here silently matches nothing.
+                const clean = docIds.filter((id) => !!id);
+                if (clean.length > 0) {
                     // Repeat $in param (Strapi accepts repeated $in keys)
-                    docIds.forEach((docId) =>
+                    clean.forEach((docId) =>
                         filters.push(
                             `filters[${field}][documentId][$in]=${encodeURIComponent(
                                 docId
@@ -527,8 +529,16 @@ export const PrevalenceDataProvider: React.FC<{ children: ReactNode }> = ({
                 field: string,
                 values: (string | number)[]
             ): void => {
-                if (values.length > 0) {
-                    values.forEach((value) =>
+                // Never send a non-numeric value to a numeric column: Strapi's
+                // NumberField.toDB throws "Expected a valid Number, got NaN" and
+                // the whole request 500s.
+                const clean = values.filter(
+                    (value) =>
+                        `${value}`.trim() !== "" &&
+                        Number.isFinite(Number(value))
+                );
+                if (clean.length > 0) {
+                    clean.forEach((value) =>
                         filters.push(
                             `filters[${field}][$eq]=${encodeURIComponent(
                                 value

--- a/src/app/prevalence/components/PrevalenceSideContent.tsx
+++ b/src/app/prevalence/components/PrevalenceSideContent.tsx
@@ -245,13 +245,17 @@ const LocalMultiSelect: React.FC<LocalMultiSelectProps> = ({
                     setFrozenOptionsWhileOpen(null);
                     onChange(staged);
                 }}
-                onChange={(e) => {
-                    const next =
-                        typeof e.target.value === "string"
-                            ? (e.target.value as string).split(",")
-                            : (e.target.value as string[]);
-                    setStaged(next);
-                }}
+                // No `onChange` on purpose. MUI's Select overrides each child
+                // MenuItem's onClick with its own handler, which appends
+                // `child.props.value` to the selection. The "Select All" row has
+                // no `value`, so that handler pushes `undefined` into the array
+                // and the resulting onChange overwrote whatever
+                // toggleSelectAllVisible had just computed — which is how `NaN`
+                // reached selectedYear (parseInt(undefined) === NaN) and then the
+                // API as `filters[samplingYear][$eq]=NaN`. Every row already
+                // drives `staged` through its own toggleValue /
+                // toggleSelectAllVisible, and the Select is fully controlled via
+                // `value`, so MUI's computed value is redundant here.
                 renderValue={(vals) => {
                     const arr = vals as string[];
                     return (
@@ -480,7 +484,11 @@ export function PrevalenceSideContent(): JSX.Element {
                     showOnlySelected={onlySel(selectedYear)}
                     onChange={(values) => {
                         if (showOnlySelected) setShowOnlySelected(false);
-                        setSelectedYear(values.map((v) => parseInt(v, 10)));
+                        setSelectedYear(
+                            values
+                                .map((v) => parseInt(v, 10))
+                                .filter(Number.isFinite)
+                        );
                         updateFilterOrder("year");
                     }}
                 />

--- a/src/app/prevalence/components/__tests__/PrevalenceSideContent.test.js
+++ b/src/app/prevalence/components/__tests__/PrevalenceSideContent.test.js
@@ -1,0 +1,95 @@
+import React from "react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { PrevalenceSideContent } from "../PrevalenceSideContent";
+import { usePrevalenceFilters } from "../PrevalenceDataContext";
+
+jest.mock("react-i18next", () => ({
+    useTranslation: () => ({
+        t: (key, fallback) => fallback ?? key,
+        i18n: { on: jest.fn(), off: jest.fn(), language: "en" },
+    }),
+}));
+
+jest.mock("../PrevalenceDataContext", () => ({
+    usePrevalenceFilters: jest.fn(),
+}));
+
+jest.mock("../../../shared/infrastructure/api/callApi.service", () => ({
+    callApiService: jest.fn().mockResolvedValue({ data: { data: [] } }),
+}));
+
+describe("PrevalenceSideContent — year filter", () => {
+    let setSelectedYear;
+
+    beforeEach(() => {
+        setSelectedYear = jest.fn();
+        usePrevalenceFilters.mockReturnValue({
+            selectedMicroorganisms: [],
+            setSelectedMicroorganisms: jest.fn(),
+            microorganismOptions: [],
+            selectedSampleOrigins: [],
+            setSelectedSampleOrigins: jest.fn(),
+            sampleOriginOptions: [],
+            selectedMatrices: [],
+            setSelectedMatrices: jest.fn(),
+            matrixOptions: [],
+            selectedSamplingStages: [],
+            setSelectedSamplingStages: jest.fn(),
+            samplingStageOptions: [],
+            selectedMatrixGroups: [],
+            setSelectedMatrixGroups: jest.fn(),
+            matrixGroupOptions: [],
+            selectedYear: [],
+            setSelectedYear,
+            yearOptions: [2020, 2021, 2022],
+            selectedSuperCategory: [],
+            setSelectedSuperCategory: jest.fn(),
+            superCategorySampleOriginOptions: [],
+            fetchDataFromAPI: jest.fn(),
+            setShowError: jest.fn(),
+            fetchOptions: jest.fn(),
+            setIsSearchTriggered: jest.fn(),
+            loading: false,
+        });
+    });
+
+    /**
+     * Regression guard. MUI's Select overrides each child MenuItem's onClick with
+     * a handler that appends `child.props.value` to the selection. The "Select
+     * All" row carries no `value`, so that handler used to push `undefined`,
+     * which parseInt turned into NaN — surfacing as a literal "NaN" entry in the
+     * dropdown and as `filters[samplingYear][$eq]=NaN` on the request, which
+     * Strapi answers with "Expected a valid Number, got NaN".
+     */
+    it("selects every year without emitting NaN when Select All is clicked", () => {
+        render(<PrevalenceSideContent />);
+
+        fireEvent.mouseDown(screen.getByLabelText("SAMPLING_YEAR"));
+        const listbox = screen.getByRole("listbox");
+        fireEvent.click(within(listbox).getByText("Select All"));
+        fireEvent.keyDown(listbox, { key: "Escape", code: "Escape" });
+
+        expect(setSelectedYear).toHaveBeenCalled();
+        const emitted =
+            setSelectedYear.mock.calls[
+                setSelectedYear.mock.calls.length - 1
+            ][0];
+        expect(emitted.every(Number.isFinite)).toBe(true);
+        expect([...emitted].sort()).toEqual([2020, 2021, 2022]);
+    });
+
+    it("selects a single year without emitting NaN", () => {
+        render(<PrevalenceSideContent />);
+
+        fireEvent.mouseDown(screen.getByLabelText("SAMPLING_YEAR"));
+        const listbox = screen.getByRole("listbox");
+        fireEvent.click(within(listbox).getByText("2021"));
+        fireEvent.keyDown(listbox, { key: "Escape", code: "Escape" });
+
+        const emitted =
+            setSelectedYear.mock.calls[
+                setSelectedYear.mock.calls.length - 1
+            ][0];
+        expect(emitted).toEqual([2021]);
+    });
+});


### PR DESCRIPTION
Selecting all sampling years put a literal "NaN" chip in the year dropdown and made the subsequent search 500 with Strapi's "Expected a valid Number, got NaN".

MUI's Select does not attach a listener to child MenuItems; it replaces each one's onClick with its own handleItemClick, which appends child.props.value to the selection. The "Select All" row is a MenuItem with no value prop, so that handler pushed `undefined` into the array, and the Select's onChange then wrote that array over what toggleSelectAllVisible had just computed.

From there: undefined -> parseInt(undefined, 10) -> NaN -> selectedYear -> rendered as the literal "NaN" -> filters[samplingYear][$eq]=NaN on the request. That is the NumberField.toDB string-branch throw seen in the CMS logs; the repeated query param is why it arrived inside an array (processAttributeWhere's Array.map frame).

Only the Select All row was affected. Individual year rows happened to work because MUI's computed value matched toggleValue's result.

- LocalMultiSelect: drop the Select's onChange. Every row already drives `staged` through toggleValue/toggleSelectAllVisible and the Select is fully controlled via `value`, so MUI's computed value was redundant as well as wrong. Comment kept so it does not get added back.
- Year onChange: filter parsed values through Number.isFinite.
- addSimpleFilter/addRelationalFilter: drop non-numeric and falsy values so nothing invalid can reach the API even if a filter regresses.
- Add PrevalenceSideContent tests covering Select All and single-year selection. Verified they fail against the pre-fix component.