### PR TITLE
fix(seo): revise page titles and descriptions

### DIFF
--- a/src/app/shared/seo/__tests__/useSeo.test.tsx
+++ b/src/app/shared/seo/__tests__/useSeo.test.tsx
@@ -120,8 +120,8 @@ describe("useSeo", () => {
         await renderAt("/prevalence", "en");
 
         expect(document.title).toContain("Prevalence");
-        expect(metaContent('meta[name="description"]')).toContain(
-            "zoonotic pathogens"
+        expect(metaContent('meta[name="description"]')).toBe(
+            seoEn.prevalence.description
         );
     });
 
@@ -212,8 +212,8 @@ describe("useSeo", () => {
         expect(metaContent('meta[property="og:title"]')).toContain(
             "Prevalence"
         );
-        expect(metaContent('meta[property="og:description"]')).toContain(
-            "zoonotic pathogens"
+        expect(metaContent('meta[property="og:description"]')).toBe(
+            seoEn.prevalence.description
         );
         expect(metaContent('meta[property="og:url"]')).toBe(
             "http://localhost/prevalence?lang=en"

--- a/src/locales/de/Seo.json
+++ b/src/locales/de/Seo.json
@@ -1,34 +1,34 @@
 {
   "home": {
-    "title": "ZooNotify — Zoonosen-Surveillancedaten des BfR",
-    "description": "Web-basierte Abfrage von Surveillancedaten gemäß RL 99/2003/EU (Zoonosenrichtlinie): Erregernachweise in der Lebensmittelkette, erhoben vom BfR."
+    "title": "ZooNotify — Web-basierte Abfrage von Daten aus dem Zoonosen Monitoring",
+    "description": "Das Bundesinstitut für Risikobewertung (BfR) stellt in diesem Portal Daten zum Vorkommen von Zoonoseerregern und deren Antibiotika-Resistenzen entlang der Lebensmittelkette in Deutschland zur Verfügung. Die Daten werden im Rahmen der Zoonosen-Überwachungsrichtlinie (Richtlinie 2003/99/EG) gesammelt."
   },
   "prevalence": {
     "title": "Prävalenz",
-    "description": "Prävalenz von Zoonoseerregern in der Lebensmittelkette in Deutschland — interaktive Auswertung nach Erreger, Matrix und Probenahmestufe.",
-    "datasetName": "Prävalenz von Zoonoseerregern in der Lebensmittelkette (Deutschland)"
+    "description": "Prävalenz von Zoonoseerregern entlang von Lebensmittelketten in Deutschland — interaktive Auswertung nach Erreger, Matrix und Probenahmestelle.",
+    "datasetName": "Prävalenz von Zoonoseerregern entlang von Lebensmittelketten (Deutschland)"
   },
   "antibioticResistance": {
     "title": "Antibiotikaresistenz",
-    "description": "Antibiotikaresistenzen bei Zoonoseerregern und kommensalen Bakterien in Deutschland — Trends, Einzelsubstanzen und Mehrfachresistenzen.",
+    "description": "Antibiotikaresistenzen von Zoonoseerregern und kommensalen Bakterien entlang von Lebensmittelketten in Deutschland — Trends, Resistenzraten und Mehrfachresistenzen.",
     "datasetName": "Antibiotikaresistenzen bei Zoonoseerregern und kommensalen Bakterien (Deutschland)"
   },
   "microbialCounts": {
     "title": "Keimzahlen",
-    "description": "Mikrobielle Keimzahlen entlang der Lebensmittelkette in Deutschland, erhoben im Rahmen des Zoonosen-Monitorings.",
-    "datasetName": "Mikrobielle Keimzahlen in der Lebensmittelkette (Deutschland)"
+    "description": "Mikrobielle Keimzahlen entlang von Lebensmittelketten in Deutschland, erhoben im Rahmen des Zoonosen-Monitorings.",
+    "datasetName": "Mikrobielle Keimzahlen entlang von Lebensmittelketten (Deutschland)"
   },
   "antimicrobial": {
     "title": "Antibiotikaeinsatz",
-    "description": "Daten zum Antibiotikaeinsatz bei lebensmittelliefernden Tieren in Deutschland, zusammengestellt vom Bundesinstitut für Risikobewertung."
+    "description": "Daten zum Antibiotikaeinsatz und zur Therapiehäufigkeit bei lebensmittelliefernden Tieren in Deutschland, zusammengestellt vom Bundesinstitut für Risikobewertung."
   },
   "evaluations": {
     "title": "Auswertungen",
-    "description": "Grafische Auswertungen und Zeitreihen zu Zoonoseerregern, Antibiotikaresistenzen und Keimzahlen aus dem deutschen Zoonosen-Monitoring."
+    "description": "Grafische Auswertungen zu mikrobiologischen Typisierungen von Zoonoseerregern und deren Antibiotikaresistenzen aus dem deutschen Zoonosen-Monitoring entlang von Lebensmittelketten."
   },
   "explanations": {
     "title": "Erläuterungen",
-    "description": "Begriffe, Methoden und Datengrundlagen des Zoonosen-Monitorings: Erläuterungen zu Erregern, Matrizes, Probenahmestufen und Resistenzdaten."
+    "description": "Hintergrundinformationen zu ZooNotify und zum Zoonosen-Monitoring: Erläuterungen zu Methoden der Isolatgewinnung und Antibiotikaresistenztestung, zu Datenvisualisierungen und zur Verwendung der Daten."
   },
   "links": {
     "title": "Externe Links",
@@ -36,7 +36,7 @@
   },
   "dataProtection": {
     "title": "Datenschutzerklärung",
-    "description": "Datenschutzerklärung für ZooNotify, das Portal für Zoonosen-Surveillancedaten des Bundesinstituts für Risikobewertung (BfR)."
+    "description": "Datenschutzerklärung für ZooNotify, das Portal für Zoonosen-Monitoring-Daten des Bundesinstituts für Risikobewertung (BfR)."
   },
   "notFound": {
     "title": "Seite nicht gefunden",

--- a/src/locales/en/Seo.json
+++ b/src/locales/en/Seo.json
@@ -1,34 +1,34 @@
 {
   "home": {
-    "title": "ZooNotify — Zoonotic Disease Surveillance Data from the BfR",
-    "description": "Web-based query tool for surveillance data collected under Directive 99/2003/EC (Zoonoses Directive): pathogen findings along the food chain, published by the BfR."
+    "title": "ZooNotify — Web-based query tool for zoonoses monitoring data",
+    "description": "The Federal Institute for Risk Assessment (BfR) provides data on the occurrence of zoonotic agents and their antimicrobial resistance along the food chain in Germany through this portal. The data are collected in accordance with the Zoonoses Monitoring Directive (Directive 2003/99/EC). ZooNotify allows users to filter and visualize the data. In addition, the data and generated graphs can be downloaded, making it easier to reuse and repurpose them."
   },
   "prevalence": {
     "title": "Prevalence",
-    "description": "Prevalence of zoonotic pathogens along the German food chain — explore the data interactively by pathogen, matrix and sampling stage.",
-    "datasetName": "Prevalence of zoonotic pathogens along the food chain (Germany)"
+    "description": "Prevalence of zoonotic agents along the German food chain — explore the data interactively by pathogen, matrix and sampling stage.",
+    "datasetName": "Prevalence of zoonotic agents along the food chain (Germany)"
   },
   "antibioticResistance": {
     "title": "Antibiotic Resistance",
-    "description": "Antimicrobial resistance in zoonotic and commensal bacteria in Germany — trends, individual substances and multi-resistance patterns.",
+    "description": "Antimicrobial resistance in zoonotic and commensal bacteria in Germany — trends, resistance rates and multi-resistance.",
     "datasetName": "Antimicrobial resistance in zoonotic and commensal bacteria (Germany)"
   },
   "microbialCounts": {
     "title": "Microbial Counts",
-    "description": "Microbial counts along the German food chain, collected as part of the national zoonoses monitoring programme.",
+    "description": "Microbial counts along the German food chain, collected as part of the national zoonoses monitoring.",
     "datasetName": "Microbial counts along the food chain (Germany)"
   },
   "antimicrobial": {
     "title": "Antimicrobial Use",
-    "description": "Data on antimicrobial use in food-producing animals in Germany, compiled by the German Federal Institute for Risk Assessment (BfR)."
+    "description": "Data on antimicrobial consumption quantities and treatment frequencies in food-producing animals in Germany, compiled by the German Federal Institute for Risk Assessment (BfR)."
   },
   "evaluations": {
     "title": "Evaluations",
-    "description": "Charts and time series covering zoonotic pathogens, antimicrobial resistance and microbial counts from the German zoonoses monitoring programme."
+    "description": "Graphical evaluations of microbiological typing of zoonotic pathogens and their antibiotic resistance from the German zoonosis monitoring across food chains."
   },
   "explanations": {
     "title": "Explanations",
-    "description": "Terminology, methods and data sources behind the zoonoses monitoring programme: pathogens, matrices, sampling stages and resistance data explained."
+    "description": "Background information on ZooNotify and zoonosis monitoring: explanations of methods for isolating strains and testing for antibiotic resistance, data visualisations and the use of the data."
   },
   "links": {
     "title": "External Links",
@@ -36,7 +36,7 @@
   },
   "dataProtection": {
     "title": "Privacy Policy",
-    "description": "Privacy policy for ZooNotify, the zoonotic disease surveillance data portal of the German Federal Institute for Risk Assessment (BfR)."
+    "description": "Privacy policy for ZooNotify, the zoonoses monitoring data portal of the German Federal Institute for Risk Assessment (BfR)."
   },
   "notFound": {
     "title": "Page not found",


### PR DESCRIPTION
Rework the English and German SEO copy to describe the portal as zoonoses monitoring data rather than surveillance data, and to speak of zoonotic agents along food chains.

Assert the prevalence description against the English locale file instead of a hardcoded substring, so rewording the copy no longer breaks the language and Open Graph tests.

Also drop the UTF-8 BOM both locale files picked up on save, trim stray leading and trailing spaces from three English descriptions, remove a stray quote character, and fix the German "Monitoging" typo.