### PR TITLE
feat(prevalence): mark every year on the chart year slider

### DIFF
--- a/src/app/prevalence/components/PrevalenceChart.tsx
+++ b/src/app/prevalence/components/PrevalenceChart.tsx
@@ -71,6 +71,26 @@ const PrevalenceChart: React.FC = () => {
         microYearMax,
     ];
 
+    /**
+     * Tick marks for the year slider: one tick per year that actually has
+     * data. Labels are thinned to at most ~10 so they stay readable on long
+     * spans; the first and last year are always labelled so the bounds of the
+     * window are legible without dragging.
+     */
+    const yearMarks = useMemo(() => {
+        if (microYears.length < 2) return [];
+        const labelEvery = Math.ceil(microYears.length / 10);
+        return microYears.map((year, index) => ({
+            value: year,
+            label:
+                index === 0 ||
+                index === microYears.length - 1 ||
+                index % labelEvery === 0
+                    ? String(year)
+                    : undefined,
+        }));
+    }, [microYears]);
+
     // Reset the window to full span whenever the plotted microorganism or its
     // year bounds change (microorganism switch or a fresh search). `null` = full.
     useEffect(() => {
@@ -314,11 +334,23 @@ const PrevalenceChart: React.FC = () => {
                                 min={microYearMin}
                                 max={microYearMax}
                                 step={1}
+                                marks={yearMarks}
                                 valueLabelDisplay="auto"
                                 aria-labelledby="chart-year-range-label"
                                 onChange={(_, value) =>
                                     setChartYearRange(value as [number, number])
                                 }
+                                sx={{
+                                    // Room for the year tick labels below the
+                                    // rail; the value balloons only appear on
+                                    // hover/drag, so no extra space above.
+                                    mt: 1,
+                                    mb: 3,
+                                    "& .MuiSlider-markLabel": {
+                                        fontSize: "0.7rem",
+                                        color: "text.secondary",
+                                    },
+                                }}
                             />
                         </Box>
                     )}

--- a/src/app/prevalence/components/__tests__/PrevalenceChart.test.js
+++ b/src/app/prevalence/components/__tests__/PrevalenceChart.test.js
@@ -162,6 +162,45 @@ describe("PrevalenceChart — Chart year window slider", () => {
         );
     });
 
+    it("shows the thumb value balloons only on hover/drag", () => {
+        mockContext();
+        const { container } = render(<PrevalenceChart />);
+
+        // Value balloons stay closed until the user interacts with a thumb.
+        expect(
+            container.querySelectorAll(".MuiSlider-valueLabelOpen")
+        ).toHaveLength(0);
+    });
+
+    it("marks every year of the span on the slider rail", () => {
+        mockContext();
+        const { container } = render(<PrevalenceChart />);
+
+        expect(container.querySelectorAll(".MuiSlider-mark")).toHaveLength(3);
+        const markLabels = Array.from(
+            container.querySelectorAll(".MuiSlider-markLabel")
+        ).map((node) => node.textContent);
+        expect(markLabels).toEqual(["2020", "2021", "2022"]);
+    });
+
+    it("thins the mark labels on a long span but keeps the bounds labelled", () => {
+        const years = Array.from({ length: 24 }, (_, i) => 2000 + i);
+        mockContext({
+            prevalenceData: dataForYears(years),
+            yearOptions: years,
+        });
+        const { container } = render(<PrevalenceChart />);
+
+        // A tick per year, but far fewer labels.
+        expect(container.querySelectorAll(".MuiSlider-mark")).toHaveLength(24);
+        const markLabels = Array.from(
+            container.querySelectorAll(".MuiSlider-markLabel")
+        ).map((node) => node.textContent);
+        expect(markLabels.length).toBeLessThanOrEqual(12);
+        expect(markLabels[0]).toBe("2000");
+        expect(markLabels[markLabels.length - 1]).toBe("2023");
+    });
+
     it("drops years outside the window from the rendered charts", () => {
         mockContext();
         render(<PrevalenceChart />);


### PR DESCRIPTION
The "Angezeigter Jahresbereich" slider gave no visual reference for the selected window: the year values only surfaced in the hover balloon, so the range was unreadable at rest.

Add a tick per year the selected microorganism has data for. Labels are thinned to at most ~10 on long spans, with the first and last year always labelled so the bounds stay legible. Value balloons remain hover-only.

Ticket: #1830